### PR TITLE
fix: use explicit version instead of version.workspace

### DIFF
--- a/crates/arey/Cargo.toml
+++ b/crates/arey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arey"
-version.workspace = true
+version = "0.0.7"
 edition.workspace = true
 
 [[bin]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arey-core"
-version.workspace = true
+version = "0.0.7"
 edition.workspace = true
 
 [lib]


### PR DESCRIPTION
See https://github.com/googleapis/release-please/issues/2111