### PR TITLE
refactor: improve REPL commands to show current and available options by default

### DIFF
--- a/crates/arey/Cargo.toml
+++ b/crates/arey/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true
 tokio.workspace = true
-rustyline = { version = "17.0.1", features = ["derive"] }
+rustyline = { version = "17.0.1", features = ["derive", "with-file-history"] }
 shlex = "1.3.0"
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = [

--- a/crates/arey/src/svc/chat.rs
+++ b/crates/arey/src/svc/chat.rs
@@ -227,6 +227,11 @@ impl<'a> Chat<'a> {
         self.config.agents.keys().map(|s| s.as_str()).collect()
     }
 
+    /// Get available tool names
+    pub fn available_tool_names(&self) -> Vec<&str> {
+        self.available_tools.keys().copied().collect()
+    }
+
     /// Get available agents with their sources
     pub fn available_agents_with_sources(&self) -> Vec<(&str, &AgentSource)> {
         self.config


### PR DESCRIPTION
- Update /model, /tool, /profile, and /agent commands to display both current status and available options when called without arguments
- Remove explicit 'list' argument support from all REPL commands
- Maintain '/tool clear' functionality for removing active tools
- Simplify completion system by removing 'list' from candidate lists
- Update help text and tests to reflect new behavior
- Improve user experience by making available options more discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)