### PR TITLE
refactor: rename thinking to reasoning, add SessionConfig, context management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ rust-project.json
 
 .aider*
 coverage.json
+coverage/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wiremock",
+ "yare",
 ]
 
 [[package]]
@@ -1454,9 +1455,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.141"
+version = "0.1.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e168663718200aaa86617d352a264ce0226bc7727139e9601e9aae926a06fb1"
+checksum = "d564eb5d7ae88f596e7636ffd549e0f27f4c938a7c7841bb91e2a92c248c9ccb"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -1468,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.141"
+version = "0.1.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec26e2c8669ac39957505d725f1e06afc79f6f813b67b2b52c2736d65309dc1e"
+checksum = "2f2cf3435dbadb87817e0a95325c818cd89d43026e8ba1ddd32f1d980d96f33d"
 dependencies = [
  "bindgen",
  "cc",
@@ -3375,6 +3376,26 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yare"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd38b61ea41431e67d75175dedcf452d555e99a08a5d0cf9ea6fdd35ef615c7c"
+dependencies = [
+ "yare-macro",
+]
+
+[[package]]
+name = "yare-macro"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8d4626f0bd81499df0d68262eb1b819b0025edc6832ade7fbf10597b008efe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,23 @@ once_cell = "1.21.4"
 path-absolutize = "3.1"
 rand = "0.10.0"
 regex = "1.12.3"
-reqwest = { version = "^0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "http2"] }
+reqwest = { version = "^0.12", default-features = false, features = [
+    "rustls-tls-native-roots",
+    "json",
+    "http2",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 shellexpand = "3.1.2"
 thiserror = "2.0"
-tokio = { version = "1.50", features = ["macros", "rt-multi-thread", "sync", "signal", "time"] }
+tokio = { version = "1.50", features = [
+    "macros",
+    "rt-multi-thread",
+    "sync",
+    "signal",
+    "time",
+] }
 tokio-stream = "0.1.18"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
@@ -45,7 +55,4 @@ tracing-subscriber = { version = "0.3", features = [
 tempfile = "3.27.0"
 url = "2.5.7"
 wiremock = "0.6.5"
-
-# [workspace.dev-dependencies]
-# futures = { version = "0.3", features = ["async-await"] }
-# tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+yare = "3"

--- a/crates/arey/src/cli/chat/commands.rs
+++ b/crates/arey/src/cli/chat/commands.rs
@@ -354,12 +354,12 @@ impl Command {
         let mut chat_guard = session.lock().await;
         match mode {
             Some(m) if m == "on" => {
-                chat_guard.set_enable_thinking(Some(true));
-                println!("Thinking enabled.");
+                chat_guard.set_enable_reasoning(Some(true));
+                println!("Reasoning enabled.");
             }
             Some(m) if m == "off" => {
-                chat_guard.set_enable_thinking(Some(false));
-                println!("Thinking disabled.");
+                chat_guard.set_enable_reasoning(Some(false));
+                println!("Reasoning disabled.");
             }
             Some(m) => {
                 eprintln!(
@@ -368,11 +368,11 @@ impl Command {
                 );
             }
             None => {
-                let current = chat_guard.enable_thinking();
+                let current = chat_guard.enable_reasoning();
                 match current {
-                    Some(true) => println!("Thinking: on"),
-                    Some(false) => println!("Thinking: off"),
-                    None => println!("Thinking: not set (using model default)"),
+                    Some(true) => println!("Reasoning: on"),
+                    Some(false) => println!("Reasoning: off"),
+                    None => println!("Reasoning: not set (using model default)"),
                 }
             }
         }
@@ -496,8 +496,8 @@ mod tests {
     use super::*;
     use crate::cli::chat::test_utils::{MockTool, create_test_config_with_custom_agent};
     use arey_core::completion::{ChatMessage, SenderType};
+    use arey_core::registry::ToolRegistry;
     use arey_core::tools::{Tool, ToolCall};
-    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
@@ -643,7 +643,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_model_command_switch() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test switching to an available model
@@ -660,7 +664,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_model_command_current() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test /model (just ensure it runs without panic)
@@ -673,7 +681,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_model_command_invalid() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test switching to a non-existent model
@@ -690,7 +702,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_profile_command_switch() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test switching to test-profile
@@ -710,7 +726,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_profile_command_invalid() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test switching to a non-existent profile
@@ -731,7 +751,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_profile_command_current() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test /profile (just ensure it runs without panic)
@@ -746,10 +770,10 @@ USER: Run tool
         // Create Chat instance with a mock tool
         let config = create_test_config_with_custom_agent()?;
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool)]);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool)?;
 
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), available_tools)?;
+        let chat = Chat::new(&config, Some("test-model-1".to_string()), tool_registry)?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test setting a tool
@@ -775,10 +799,10 @@ USER: Run tool
         // Create Chat instance with a mock tool
         let config = create_test_config_with_custom_agent()?;
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool)]);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool)?;
 
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), available_tools)?;
+        let chat = Chat::new(&config, Some("test-model-1".to_string()), tool_registry)?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Set a tool first
@@ -804,10 +828,10 @@ USER: Run tool
         // Create Chat instance with a mock tool
         let config = create_test_config_with_custom_agent()?;
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool)]);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool)?;
 
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), available_tools)?;
+        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), tool_registry)?;
         chat.load_session().await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
@@ -821,7 +845,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_tool_command_invalid() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
@@ -839,7 +867,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_clear_command() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
@@ -859,6 +891,7 @@ USER: Run tool
         let clear_cmd = Command::Clear;
         assert!(clear_cmd.execute(chat_session.clone()).await?);
         assert!(chat_session.lock().await.get_all_messages().is_empty());
+        assert!(chat_session.lock().await.was_model_reset());
 
         Ok(())
     }
@@ -866,7 +899,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_log_command() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Add a message first
@@ -890,7 +927,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_system_command_set() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test setting system prompt
@@ -907,7 +948,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_system_command_view() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
@@ -921,15 +966,19 @@ USER: Run tool
     #[tokio::test]
     async fn test_think_command_enable() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
-        // Test enabling thinking
+        // Test enabling reasoning
         let think_cmd = Command::Think {
             mode: Some("on".to_string()),
         };
         assert!(think_cmd.execute(chat_session.clone()).await?);
-        assert_eq!(chat_session.lock().await.enable_thinking(), Some(true));
+        assert_eq!(chat_session.lock().await.enable_reasoning(), Some(true));
 
         Ok(())
     }
@@ -937,15 +986,19 @@ USER: Run tool
     #[tokio::test]
     async fn test_think_command_disable() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
-        // Test disabling thinking
+        // Test disabling reasoning
         let think_cmd = Command::Think {
             mode: Some("off".to_string()),
         };
         assert!(think_cmd.execute(chat_session.clone()).await?);
-        assert_eq!(chat_session.lock().await.enable_thinking(), Some(false));
+        assert_eq!(chat_session.lock().await.enable_reasoning(), Some(false));
 
         Ok(())
     }
@@ -953,16 +1006,20 @@ USER: Run tool
     #[tokio::test]
     async fn test_think_command_view() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
-        // First, set thinking to true
+        // First, set reasoning to true
         {
             let mut chat_guard = chat_session.lock().await;
-            chat_guard.set_enable_thinking(Some(true));
+            chat_guard.set_enable_reasoning(Some(true));
         }
 
-        // Test viewing current thinking state
+        // Test viewing current reasoning state
         let view_cmd = Command::Think { mode: None };
         assert!(view_cmd.execute(chat_session.clone()).await?);
 
@@ -972,7 +1029,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_think_command_invalid() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
@@ -982,7 +1043,7 @@ USER: Run tool
         };
         assert!(think_cmd.execute(chat_session.clone()).await?);
         // State should not change
-        assert_eq!(chat_session.lock().await.enable_thinking(), None);
+        assert_eq!(chat_session.lock().await.enable_reasoning(), None);
 
         Ok(())
     }
@@ -990,7 +1051,11 @@ USER: Run tool
     #[tokio::test]
     async fn test_exit_command() -> Result<()> {
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         // Test exit command

--- a/crates/arey/src/cli/chat/mod.rs
+++ b/crates/arey/src/cli/chat/mod.rs
@@ -2,8 +2,7 @@ use crate::cli::ux::{TerminalRenderer, get_theme};
 use crate::svc::chat::Chat;
 use anyhow::{Context, Result};
 use arey_core::config::Config;
-use arey_core::tools::Tool;
-use std::collections::HashMap;
+use arey_core::registry::ToolRegistry;
 use std::io::stdout;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -18,10 +17,10 @@ mod test_utils;
 pub async fn execute(
     model: Option<String>,
     config: &Config,
-    available_tools: HashMap<&str, Arc<dyn Tool>>,
+    tool_registry: ToolRegistry,
 ) -> Result<()> {
     let chat =
-        Chat::new(config, model, available_tools).context("Failed to initialize chat service")?;
+        Chat::new(config, model, tool_registry).context("Failed to initialize chat service")?;
     let theme = get_theme("ansi"); // TODO: Theme from config
     let mut stdout = stdout();
     let mut renderer = TerminalRenderer::new(&mut stdout, &theme);

--- a/crates/arey/src/cli/chat/prompt.rs
+++ b/crates/arey/src/cli/chat/prompt.rs
@@ -59,8 +59,8 @@ pub fn format_status_prompt(chat_guard: &Chat<'_>) -> String {
 mod tests {
     use super::*;
     use crate::cli::chat::test_utils::{MockTool, create_test_config_with_custom_agent};
+    use arey_core::registry::ToolRegistry;
     use arey_core::tools::Tool;
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     /// Strip ANSI escape codes from a string for testing
@@ -92,7 +92,11 @@ mod tests {
     async fn test_format_status_prompt() -> Result<(), Box<dyn std::error::Error>> {
         // 1. Setup config and chat
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
 
         // 2. Test basic prompt with no tools
@@ -132,10 +136,10 @@ mod tests {
 
         // 3. Test prompt with tools
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool.clone())]);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool.clone())?;
         let mut chat_with_tools =
-            Chat::new(&config, Some("test-model-1".to_string()), available_tools)?;
+            Chat::new(&config, Some("test-model-1".to_string()), tool_registry)?;
         chat_with_tools.load_session().await?;
         chat_with_tools
             .set_tools(&["mock_tool".to_string()])
@@ -176,7 +180,11 @@ mod tests {
     async fn test_format_status_prompt_styling() -> Result<(), Box<dyn std::error::Error>> {
         // Test that the function applies the correct styling
         let config = create_test_config_with_custom_agent()?;
-        let mut chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let mut chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         chat.load_session().await?;
 
         let prompt = format_status_prompt(&chat);

--- a/crates/arey/src/cli/chat/repl.rs
+++ b/crates/arey/src/cli/chat/repl.rs
@@ -10,16 +10,14 @@ use arey_core::completion::{
     CancellationToken, ChatMessage, Completion, CompletionMetrics, SenderType,
 };
 use arey_core::config::get_history_file_path;
-use arey_core::tools::{Tool, ToolCall, ToolResult};
+use arey_core::session::SessionEvent;
 use clap::{CommandFactory, Parser};
 use futures::StreamExt;
 use rustyline::error::ReadlineError;
 use rustyline::{CompletionType, Editor};
-use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{debug, error};
+use tracing::error;
 
 /// Runs the interactive REPL for the chat session.
 pub async fn run(chat: Arc<Mutex<Chat<'_>>>, renderer: &mut TerminalRenderer<'_>) -> Result<()> {
@@ -53,9 +51,8 @@ pub async fn run(chat: Arc<Mutex<Chat<'_>>>, renderer: &mut TerminalRenderer<'_>
         chat_guard
             .lock()
             .await
-            .available_tools
-            .clone()
-            .keys()
+            .available_tool_names()
+            .into_iter()
             .map(|s| s.to_string())
             .collect()
     };
@@ -201,19 +198,6 @@ pub async fn run(chat: Arc<Mutex<Chat<'_>>>, renderer: &mut TerminalRenderer<'_>
     }
 }
 
-/// Recursively removes control characters from JSON values
-fn clean_value(value: &mut serde_json::Value) {
-    match value {
-        Value::String(s) => {
-            let cleaned = s.replace(|c: char| c.is_control(), "");
-            *s = cleaned;
-        }
-        Value::Array(a) => a.iter_mut().for_each(clean_value),
-        Value::Object(m) => m.values_mut().for_each(clean_value),
-        _ => {}
-    }
-}
-
 /// Process a message and generate a response.
 async fn process_message(
     chat: Arc<Mutex<Chat<'_>>>,
@@ -227,24 +211,16 @@ async fn process_message(
     renderer.clear();
 
     // Create spinner
-    let spinner = GenerationSpinner::new("Generating...".to_string());
+    let mut spinner = GenerationSpinner::new("Generating...".to_string());
     let cancel_token = CancellationToken::new();
 
     // Clone for async block
     let chat_clone = chat.clone();
 
-    // Store tool call responses if LLM requires a set of tools to be invoked for responding to a
-    // user message.
-    let mut assistant_message_text = String::new();
-    let mut assistant_message_thought = String::new();
-    let mut assistant_message_tools: Vec<ToolCall> = vec![];
-    let mut assistant_tool_responses: Vec<ChatMessage> = vec![];
-
     let mut stream_error = false;
     let was_cancelled = {
         // Get stream response
         let mut chat_guard = chat_clone.lock().await;
-        let available_tools = chat_guard.available_tools.clone();
         let mut stream = {
             chat_guard.add_messages(messages).await;
             chat_guard.stream_response(cancel_token.clone()).await?
@@ -270,43 +246,68 @@ async fn process_message(
                 next = stream.next() => {
                     match next {
                         Some(response) => {
-                            if !first_token_received {
-                                spinner.clear();
-                                first_token_received = true;
-                            }
-
                             if cancel_token.is_cancelled() {
                                 was_cancelled_internal = true;
                                 break;
                             }
 
                             match response {
-                                Ok(Completion::Response(chunk)) => {
+                                Ok(SessionEvent::Token(Completion::Response(chunk))) => {
+                                    if !first_token_received {
+                                        spinner.clear();
+                                        first_token_received = true;
+                                    }
+
                                     if let Some(thought) = &chunk.thought {
-                                        assistant_message_thought.push_str(thought);
                                         renderer.render_markdown(thought)?;
                                     }
 
                                     if !&chunk.text.is_empty() {
-                                        assistant_message_text.push_str(&chunk.text);
                                         renderer.render_markdown(&chunk.text)?;
                                     }
 
                                     if let Some(reason) = &chunk.finish_reason {
                                         finish_reason = Some(reason.clone());
                                     }
-
-                                    // Tool messages can come in chunks, we collate all
-                                    if let Some(tools) = &chunk.tool_calls {
-                                        assistant_message_tools.extend(tools.clone());
-                                        assistant_tool_responses = process_tools(&available_tools, tools).await?;
-                                    }
                                 }
-                                Ok(Completion::Metrics(m)) => {
+                                Ok(SessionEvent::Token(Completion::Metrics(m))) => {
                                     metrics = m;
                                 }
+                                Ok(SessionEvent::ToolStart { calls }) => {
+                                    spinner.clear();
+                                    let tool_info: Vec<_> = calls.iter().map(|c| format!("{}({})", c.name, c.arguments)).collect();
+                                    let tool_names_str = format!("Executing tools: {}", tool_info.join(", "));
+                                    let tool_msg = style_chat_text(&tool_names_str, ChatMessageType::Footer);
+                                    spinner = GenerationSpinner::new(tool_msg.to_string());
+                                }
+                                Ok(SessionEvent::ToolEnd { results }) => {
+                                    spinner.clear();
+
+                                    for (call, succeeded) in &results {
+                                        if *succeeded {
+                                            eprintln!("{}", style_chat_text(&format!("✔  {}({})", call.name, call.arguments), ChatMessageType::Footer));
+                                        } else {
+                                            eprintln!("{}", style_chat_text(&format!("✘  {}({})", call.name, call.arguments), ChatMessageType::Footer));
+                                        }
+                                    }
+                                    eprintln!();
+
+                                    // Reset spinner for next potential generation turn
+                                    spinner = GenerationSpinner::new("Generating...".to_string());
+                                    first_token_received = false;
+                                }
+                                Ok(SessionEvent::CompactionStart) => {
+                                    spinner.clear();
+                                    spinner = GenerationSpinner::new("Compacting context...".to_string());
+                                }
+                                Ok(SessionEvent::CompactionEnd { .. }) => {
+                                    spinner.clear();
+                                    spinner = GenerationSpinner::new("Generating...".to_string());
+                                    first_token_received = false;
+                                }
+                                Ok(_) => {} // Handle other events silently
                                 Err(e) => {
-                                    eprintln!("Error: {e}");
+                                    eprintln!("{}", style_chat_text(&format!("Error: {e}"), ChatMessageType::Error));
                                     stream_error = true;
                                     break;
                                 }
@@ -330,36 +331,8 @@ async fn process_message(
         return Ok(true);
     }
 
-    {
-        // Add the assistant message to the chat history
-        let mut chat_guard = chat.lock().await;
-        chat_guard
-            .add_messages(vec![ChatMessage {
-                sender: SenderType::Assistant,
-                text: assistant_message_text,
-                thought: if assistant_message_thought.is_empty() {
-                    None
-                } else {
-                    Some(assistant_message_thought)
-                },
-                tools: Some(assistant_message_tools),
-                metrics: Some(metrics.clone()),
-            }])
-            .await;
-    }
-
     // After a successful stream, flush any remaining partial lines from the renderer.
     renderer.render_markdown("\n")?;
-
-    // If the model produced tool calls, recursively call this function to process them.
-    if !assistant_tool_responses.is_empty() {
-        return Box::pin(process_message(
-            chat_clone,
-            renderer,
-            assistant_tool_responses,
-        ))
-        .await;
-    }
 
     // If we've reached this point, the response is complete. Print the footer.
     let (metrics, finish_reason_option) = match was_cancelled {
@@ -370,128 +343,10 @@ async fn process_message(
     let footer = format_footer_metrics(&metrics, finish_reason_option.as_deref(), was_cancelled);
 
     // The `render_markdown("\n")` above ensures we start on a fresh line.
-    println!();
-    println!("{}", style_chat_text(&footer, ChatMessageType::Footer));
+    eprintln!();
+    eprintln!("{}", style_chat_text(&footer, ChatMessageType::Footer));
 
     Ok(true)
-}
-
-/// Returns set of tool results as messages
-async fn process_tools(
-    available_tools: &HashMap<&str, Arc<dyn Tool>>,
-    tool_calls: &Vec<ToolCall>,
-) -> Result<Vec<ChatMessage>> {
-    let mut tool_messages: Vec<ChatMessage> = vec![];
-
-    for call in tool_calls {
-        eprintln!(); // Add a newline before tool output
-        let tool_fmt = format!("Tool: {}({})", call.name, call.arguments);
-        let tool_msg = style_chat_text(&tool_fmt, ChatMessageType::Footer);
-        let spinner = GenerationSpinner::new(tool_msg.to_string());
-        let tool = match available_tools.get(call.name.as_str()) {
-            Some(t) => t.clone(),
-            None => {
-                eprintln!(
-                    "{}",
-                    style_chat_text(
-                        &format!("Tool '{}' not available", call.name),
-                        ChatMessageType::Error
-                    )
-                );
-                continue;
-            }
-        };
-
-        // Normalize tool call arguments - could be direct JSON, escaped JSON, or plain string
-        debug!("Raw tool call arguments: '{}'", call.arguments);
-
-        let args = match serde_json::from_str(&call.arguments) {
-            Ok(value) => {
-                debug!("Parsed as direct JSON: {}", value);
-                value
-            }
-            Err(first_error) => {
-                debug!(
-                    "First parse failed: {}. Trying raw string parse",
-                    first_error
-                );
-                match serde_json::from_str::<Value>(&call.arguments) {
-                    Ok(value) => {
-                        debug!("Parsed as raw JSON string: {}", value);
-                        value
-                    }
-                    Err(second_error) => {
-                        debug!(
-                            "Second parse failed: {}. Falling back to input wrapper",
-                            second_error
-                        );
-                        serde_json::json!({ "input": call.arguments })
-                    }
-                }
-            }
-        };
-
-        // If we got a string, try to parse that string as JSON to see if it's really a structured value.
-        let args = match &args {
-            Value::String(s) => match serde_json::from_str(s) {
-                Ok(parsed_value) => {
-                    debug!("Unescaped inner JSON string successfully: {}", parsed_value);
-                    parsed_value
-                }
-                Err(inner_error) => {
-                    debug!(
-                        "Failed to unescape inner JSON: {}. Keeping as string.",
-                        inner_error
-                    );
-                    args
-                }
-            },
-            _ => args,
-        };
-
-        debug!("Final tool arguments: {}", args);
-        let mut output = match tool.execute(&args).await {
-            Ok(out) => out,
-            Err(e) => {
-                eprintln!(
-                    "{}",
-                    style_chat_text(
-                        &format!("Tool execution failed: {e}"),
-                        ChatMessageType::Error
-                    )
-                );
-                continue;
-            }
-        };
-
-        // Clean control characters from tool output
-        clean_value(&mut output);
-
-        spinner.clear();
-        eprintln!("✓ {tool_msg}");
-
-        // Gemini doesn't provide a tool_id, we fill it if empty
-        let call_id = if call.id.is_empty() {
-            call.name.to_string()
-        } else {
-            call.id.to_string()
-        };
-        let result = ToolResult {
-            call: ToolCall {
-                id: call_id,
-                ..call.clone()
-            },
-            output,
-        };
-        tool_messages.push(ChatMessage {
-            text: serde_json::to_string(&result)?,
-            sender: SenderType::Tool,
-            ..Default::default()
-        });
-    }
-
-    eprintln!();
-    Ok(tool_messages)
 }
 
 #[cfg(test)]
@@ -502,12 +357,10 @@ mod tests {
     use anyhow::Result;
     use arey_core::{
         completion::{ChatMessage, SenderType},
-        tools::{Tool, ToolError, ToolResult},
+        registry::ToolRegistry,
+        tools::Tool,
     };
-    use async_trait::async_trait;
-    use serde_json::{Value, json};
     use std::sync::Arc;
-    use std::vec;
     use tokio::sync::Mutex;
 
     use crate::cli::chat::test_utils::{
@@ -516,166 +369,14 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn test_process_tools() -> Result<()> {
-        let mock_tool: Arc<dyn Tool> = Arc::new(MockTool {});
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool.clone())]);
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "mock_tool".to_string(),
-            arguments: "{}".to_string(),
-        }];
-
-        let messages = process_tools(&available_tools, &tool_calls).await?;
-
-        assert_eq!(messages.len(), 1);
-        let msg = &messages[0];
-        assert_eq!(msg.sender, SenderType::Tool);
-
-        let tool_result: ToolResult = serde_json::from_str(&msg.text)?;
-        assert_eq!(tool_result.call.id, "call_1");
-        assert_eq!(tool_result.output, json!("mock tool output"));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_process_tools_with_stringified_json_argument() -> Result<()> {
-        struct ArgRecorder;
-        #[async_trait]
-        impl Tool for ArgRecorder {
-            fn name(&self) -> String {
-                "arg_recorder".to_string()
-            }
-
-            fn description(&self) -> String {
-                "Records arguments".to_string()
-            }
-
-            fn parameters(&self) -> Value {
-                json!({})
-            }
-
-            async fn execute(&self, args: &Value) -> std::result::Result<Value, ToolError> {
-                Ok(args.clone())
-            }
-        }
-
-        let tool: Arc<dyn Tool> = Arc::new(ArgRecorder);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("arg_recorder", tool.clone())]);
-        // The arguments are a string that itself is a JSON object
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "arg_recorder".to_string(),
-            arguments: r#""{\"arg\":42}""#.to_string(),
-        }];
-
-        let messages = process_tools(&available_tools, &tool_calls).await?;
-        assert_eq!(messages.len(), 1);
-        let msg = &messages[0];
-        let tool_result: ToolResult = serde_json::from_str(&msg.text)?;
-
-        // The tool should have received the parsed JSON object: {"arg":42}
-        assert_eq!(tool_result.output, json!({"arg":42}));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_process_tools_with_non_json_string() -> Result<()> {
-        struct ArgRecorder;
-        #[async_trait]
-        impl Tool for ArgRecorder {
-            fn name(&self) -> String {
-                "arg_recorder".to_string()
-            }
-
-            fn description(&self) -> String {
-                "Records arguments".to_string()
-            }
-
-            fn parameters(&self) -> Value {
-                json!({})
-            }
-
-            async fn execute(&self, args: &Value) -> std::result::Result<Value, ToolError> {
-                Ok(args.clone())
-            }
-        }
-
-        let tool: Arc<dyn Tool> = Arc::new(ArgRecorder);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("arg_recorder", tool.clone())]);
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "arg_recorder".to_string(),
-            arguments: "plain string".to_string(),
-        }];
-
-        let messages = process_tools(&available_tools, &tool_calls).await?;
-
-        assert_eq!(messages.len(), 1);
-        let msg = &messages[0];
-        let tool_result: ToolResult = serde_json::from_str(&msg.text)?;
-
-        // We expect the tool to have received: {"input": "plain string"}
-        assert_eq!(tool_result.output, json!({ "input": "plain string" }));
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_process_tools_cleans_control_characters() -> Result<()> {
-        #[derive(Debug)]
-        struct ControlCharTool;
-        #[async_trait]
-        impl Tool for ControlCharTool {
-            fn name(&self) -> String {
-                "control_tool".to_string()
-            }
-
-            fn description(&self) -> String {
-                "Tool with control characters".to_string()
-            }
-
-            fn parameters(&self) -> Value {
-                json!({})
-            }
-
-            async fn execute(&self, _args: &Value) -> std::result::Result<Value, ToolError> {
-                // Return value containing control characters
-                Ok(json!({
-                    "key": "value with \u{0001} control \u{001F} characters"
-                }))
-            }
-        }
-
-        let tool: Arc<dyn Tool> = Arc::new(ControlCharTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("control_tool", tool.clone())]);
-        let tool_calls = vec![ToolCall {
-            id: "call_1".to_string(),
-            name: "control_tool".to_string(),
-            arguments: "{}".to_string(),
-        }];
-
-        let messages = process_tools(&available_tools, &tool_calls).await?;
-        assert_eq!(messages.len(), 1);
-        let msg = &messages[0];
-        let tool_result: ToolResult = serde_json::from_str(&msg.text)?;
-
-        // Check that control characters were removed
-        let output_str = tool_result.output.get("key").unwrap().as_str().unwrap();
-        assert_eq!(output_str, "value with  control  characters");
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_process_message_simple_response() -> Result<()> {
         // 1. Setup Chat and Renderer
         let config = create_test_config_with_custom_agent()?;
-        let chat = Chat::new(&config, Some("test-model-1".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("test-model-1".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
         let mut buffer = Vec::new();
         let theme = get_theme("ansi");
@@ -700,13 +401,11 @@ mod tests {
     async fn test_process_message_with_tool_call() -> Result<()> {
         let config = create_test_config_with_tool_call_model()?;
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools: HashMap<&str, Arc<dyn Tool>> =
-            HashMap::from([("mock_tool", mock_tool)]);
-        let chat = Chat::new(
-            &config,
-            Some("tool-call-model".to_string()),
-            available_tools,
-        )?;
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool)?;
+        let mut chat = Chat::new(&config, Some("tool-call-model".to_string()), tool_registry)?;
+        chat.load_session().await?;
+        chat.set_tools(&["mock_tool".to_string()]).await?;
         let chat_session = Arc::new(Mutex::new(chat));
 
         let mut buffer = Vec::new();
@@ -729,7 +428,11 @@ mod tests {
     #[tokio::test]
     async fn test_process_message_stream_error() -> Result<()> {
         let config = create_test_config_with_error_model()?;
-        let chat = Chat::new(&config, Some("error-model".to_string()), HashMap::new())?;
+        let chat = Chat::new(
+            &config,
+            Some("error-model".to_string()),
+            ToolRegistry::new(),
+        )?;
         let chat_session = Arc::new(Mutex::new(chat));
         let mut buffer = Vec::new();
         let theme = get_theme("ansi");

--- a/crates/arey/src/cli/chat/test_utils.rs
+++ b/crates/arey/src/cli/chat/test_utils.rs
@@ -1,7 +1,6 @@
-#![cfg(test)]
-
 //! Test utilities for chat modules
 
+#![cfg(test)]
 #![allow(dead_code)]
 
 use anyhow::Result;

--- a/crates/arey/src/cli/mod.rs
+++ b/crates/arey/src/cli/mod.rs
@@ -4,12 +4,9 @@ mod play;
 mod run;
 pub mod ux;
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use arey_core::config::{Config, get_config};
-use arey_core::tools::Tool;
+use arey_core::registry::ToolRegistry;
 use clap::{Parser, Subcommand};
 
 use crate::ext::get_tools;
@@ -70,13 +67,13 @@ pub async fn run() -> Result<()> {
     let config = get_config(None).context("Failed to load configuration")?;
 
     // Initialize all available tools
-    let available_tools = get_tools(&config).context("Failed to get builtin tools")?;
+    let tool_registry = get_tools(&config).context("Failed to get builtin tools")?;
 
     match &cli.command {
         Commands::Run { instruction, model } => {
             run::execute(instruction.clone(), model.clone(), &config).await
         }
-        Commands::Chat { model } => execute_chat(model.clone(), &config, available_tools).await,
+        Commands::Chat { model } => execute_chat(model.clone(), &config, tool_registry).await,
         Commands::Play { file, no_watch } => {
             play::execute(file.as_deref(), *no_watch, &config).await
         }
@@ -86,9 +83,9 @@ pub async fn run() -> Result<()> {
 async fn execute_chat(
     model: Option<String>,
     config: &Config,
-    available_tools: HashMap<&str, Arc<dyn Tool>>,
+    tool_registry: ToolRegistry,
 ) -> Result<()> {
-    crate::cli::chat::execute(model, config, available_tools).await
+    crate::cli::chat::execute(model, config, tool_registry).await
 }
 
 #[cfg(test)]

--- a/crates/arey/src/cli/play.rs
+++ b/crates/arey/src/cli/play.rs
@@ -100,9 +100,8 @@ pub async fn execute(file: Option<&str>, no_watch: bool, config: &Config) -> Res
 async fn run_once(play_file: &mut PlayFile) -> Result<()> {
     if play_file.session.is_none() {
         play_file.ensure_session().await?;
-        if let Some(session) = &play_file.session
-            && let Some(metrics) = session.metrics()
-        {
+        if let Some(session) = &play_file.session {
+            let metrics = session.metrics();
             println!(
                 "{} {}",
                 style_chat_text("✓ Model loaded.", ChatMessageType::Footer),

--- a/crates/arey/src/ext/mod.rs
+++ b/crates/arey/src/ext/mod.rs
@@ -1,9 +1,9 @@
 //! Extensions for arey.
 //! Support for tools, agents, workflows, and memory extensions.
 use anyhow::{Context, Result, anyhow};
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use arey_core::{config::Config, tools::Tool};
+use arey_core::{config::Config, registry::ToolRegistry, tools::Tool};
 
 /// Retrieves all available tools from the configuration.
 ///
@@ -17,17 +17,16 @@ use arey_core::{config::Config, tools::Tool};
 ///
 /// # Returns
 ///
-/// A `Result` containing a `HashMap` mapping tool names to their corresponding
-/// `Tool` trait objects, or an error if initialization fails or an unknown tool
-/// is encountered.
+/// A `Result` containing a `ToolRegistry` with all available tools, or an error
+/// if initialization fails or an unknown tool is encountered.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - A tool fails to initialize (e.g., due to invalid configuration).
 /// - An unknown tool name is found in the configuration.
-pub fn get_tools<'a>(config: &'a Config) -> Result<HashMap<&'a str, Arc<dyn Tool>>> {
-    let mut available_tools: HashMap<&'a str, Arc<dyn Tool>> = HashMap::new();
+pub fn get_tools(config: &Config) -> Result<ToolRegistry> {
+    let mut registry = ToolRegistry::new();
     for (name, tool_config) in &config.tools {
         let tool: Arc<dyn Tool> = match name.as_str() {
             "search" => Arc::new(
@@ -36,8 +35,8 @@ pub fn get_tools<'a>(config: &'a Config) -> Result<HashMap<&'a str, Arc<dyn Tool
             ),
             _ => return Err(anyhow!("Unknown tool in config: {}", name)),
         };
-        available_tools.insert(name.as_str(), tool);
+        registry.register(tool)?;
     }
 
-    Ok(available_tools)
+    Ok(registry)
 }

--- a/crates/arey/src/svc/chat.rs
+++ b/crates/arey/src/svc/chat.rs
@@ -1,31 +1,40 @@
 use anyhow::{Context, Result};
 use arey_core::agent::{Agent, AgentSource};
-use arey_core::completion::{CancellationToken, ChatMessage, Completion};
+use arey_core::completion::{CancellationToken, ChatMessage};
 use arey_core::config::{Config, ProfileConfig};
-use arey_core::session::Session;
+use arey_core::model::ModelConfig;
+use arey_core::registry::ToolRegistry;
+use arey_core::session::{Session, SessionConfig, SessionEvent};
 use arey_core::tools::Tool;
 use futures::{StreamExt, stream::BoxStream};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use tracing::debug;
 
 /// Represents an interactive chat session between a user and an AI model.
 ///
 /// It maintains conversation history and manages tool usage.
 pub struct Chat<'a> {
-    session: Option<Session>,
-    model_config: Option<arey_core::model::ModelConfig>,
-    current_agent: Agent,
-    pub available_tools: HashMap<&'a str, Arc<dyn Tool>>,
     config: &'a Config,
+    model_config: ModelConfig,
+    session_config: SessionConfig,
+    current_agent: Agent,
+    session: Option<Session>,
+    tool_registry: ToolRegistry,
 }
 
 impl<'a> fmt::Debug for Chat<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Chat")
             .field(
-                "available_tools",
-                &self.available_tools.keys().collect::<Vec<_>>(),
+                "tool_names",
+                &self
+                    .session_config
+                    .tools
+                    .iter()
+                    .map(|t| t.name())
+                    .collect::<Vec<_>>(),
             )
             .finish_non_exhaustive()
     }
@@ -39,7 +48,7 @@ impl<'a> Chat<'a> {
     pub fn new(
         config: &'a Config,
         model: Option<String>,
-        available_tools: HashMap<&'a str, Arc<dyn Tool>>,
+        tool_registry: arey_core::registry::ToolRegistry,
     ) -> Result<Self> {
         let model_config = if let Some(model_name) = model {
             config
@@ -72,11 +81,21 @@ impl<'a> Chat<'a> {
         // Mark this agent as active
         agent.set_active(true);
 
+        // Get tools from registry based on agent's effective tools
+        let tools = tool_registry.tools_for(agent.effective_tools());
+
+        let session_config = SessionConfig {
+            system_prompt: agent.prompt.clone(),
+            tools,
+            ..Default::default()
+        };
+
         Ok(Self {
             session: None,
-            model_config: Some(model_config),
+            model_config,
+            session_config,
             current_agent: agent,
-            available_tools,
+            tool_registry,
             config,
         })
     }
@@ -91,18 +110,8 @@ impl<'a> Chat<'a> {
             return Ok(());
         }
 
-        let model_config = self.model_config.take().context("Session already loaded")?;
-
-        let tools: Vec<Arc<dyn Tool>> = self
-            .current_agent
-            .effective_tools()
-            .iter()
-            .filter_map(|tool_name| self.available_tools.get(tool_name.as_str()).cloned())
-            .collect();
-
-        let mut session = Session::new(model_config, &self.current_agent.prompt)
+        let session = Session::new(self.model_config.clone(), self.session_config.clone())
             .context("Failed to create chat session")?;
-        session.set_tools(tools)?;
 
         self.session = Some(session);
         Ok(())
@@ -112,18 +121,12 @@ impl<'a> Chat<'a> {
     /// This is a blocking wrapper around load_session.
     #[cfg(test)]
     pub fn load_session_blocking(&mut self) -> Result<()> {
-        let model_config = self.model_config.take().context("Session already loaded")?;
+        if self.session.is_some() {
+            return Ok(());
+        }
 
-        let tools: Vec<Arc<dyn Tool>> = self
-            .current_agent
-            .effective_tools()
-            .iter()
-            .filter_map(|tool_name| self.available_tools.get(tool_name.as_str()).cloned())
-            .collect();
-
-        let mut session = Session::new(model_config, &self.current_agent.prompt)
+        let session = Session::new(self.model_config.clone(), self.session_config.clone())
             .context("Failed to create chat session")?;
-        session.set_tools(tools)?;
 
         self.session = Some(session);
         Ok(())
@@ -164,21 +167,7 @@ impl<'a> Chat<'a> {
             return;
         }
 
-        let model_config = match self.model_config.take() {
-            Some(c) => c,
-            None => return,
-        };
-
-        let tools: Vec<Arc<dyn Tool>> = self
-            .current_agent
-            .effective_tools()
-            .iter()
-            .filter_map(|tool_name| self.available_tools.get(tool_name.as_str()).cloned())
-            .collect();
-
-        if let Ok(mut session) = Session::new(model_config, &self.current_agent.prompt)
-            && session.set_tools(tools).is_ok()
-        {
+        if let Ok(session) = Session::new(self.model_config.clone(), self.session_config.clone()) {
             self.session = Some(session);
         }
     }
@@ -190,10 +179,18 @@ impl<'a> Chat<'a> {
 
     /// Get the model name that will be loaded
     pub fn model_key(&self) -> String {
-        self.model_config
-            .as_ref()
-            .map(|c| c.key.clone())
-            .unwrap_or_else(|| self.session().model_key())
+        if let Some(ref session) = self.session {
+            session.model_key().to_string()
+        } else {
+            self.model_config.key.clone()
+        }
+    }
+
+    fn update_session_config(&mut self, config: SessionConfig) {
+        self.session_config = config.clone();
+        if let Some(session) = self.session.as_mut() {
+            session.update_config(config);
+        }
     }
 
     /// Switch to a different agent
@@ -209,35 +206,33 @@ impl<'a> Chat<'a> {
         self.current_agent.set_active(false);
 
         let model_key = self.session().model_key();
-        let _model_config = self
-            .config
-            .models
-            .get(&model_key)
-            .cloned()
-            .context(format!(
-                "Model '{}' associated with the current session not found in config.",
-                model_key
-            ))?;
-
-        let _messages = self.session().all_messages();
+        let _model_config = self.config.models.get(model_key).cloned().context(format!(
+            "Model '{}' associated with the current session not found in config.",
+            model_key
+        ))?;
 
         // Activate new agent
         new_agent.set_active(true);
 
-        let tools: Result<Vec<Arc<dyn Tool>>, _> = new_agent
-            .effective_tools()
-            .iter()
-            .map(|name| {
-                self.available_tools
-                    .get(name.as_str())
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("Tool not found: {}", name))
-            })
-            .collect();
+        // Ensure we clear any session overrides when switching agent
+        new_agent.set_session_tools(None);
+        new_agent.clear_current_profile();
+
+        // Get new tools from registry for new agent
+        let tools = self.tool_registry.tools_for(new_agent.effective_tools());
+        debug!(
+            "Tools for agent '{}': {:?}",
+            new_agent.name,
+            tools.iter().map(|f| f.name()).collect::<Vec<_>>()
+        );
 
         // Update the session with new agent and tools
-        self.session_mut()
-            .update_agent(new_agent.prompt.clone(), tools?)?;
+        let new_config = SessionConfig {
+            system_prompt: new_agent.prompt.clone(),
+            tools,
+            ..self.session_config.clone()
+        };
+        self.update_session_config(new_config);
         self.current_agent = new_agent;
 
         Ok(())
@@ -253,7 +248,7 @@ impl<'a> Chat<'a> {
             .context(format!("Model '{model_name}' not found in config."))?;
 
         // Session handles model creation and old model cleanup
-        self.session_mut().set_model(model_config)?;
+        self.session_mut().update_model(model_config)?;
 
         Ok(())
     }
@@ -304,26 +299,28 @@ impl<'a> Chat<'a> {
 
     /// Get current system prompt
     pub fn system_prompt(&self) -> String {
-        self.session().system_prompt()
+        self.session_config.system_prompt.clone()
     }
 
     /// Set new system prompt for the current session
     pub async fn set_system_prompt(&mut self, prompt: &str) -> Result<()> {
-        // Update the session with the new system prompt
-        self.session_mut().set_system_prompt(prompt)?;
-
+        let mut config = self.session_config.clone();
+        config.system_prompt = prompt.to_string();
+        self.update_session_config(config);
         Ok(())
     }
 
-    /// Get the enable_thinking setting
-    pub fn enable_thinking(&self) -> Option<bool> {
-        self.session().enable_thinking()
+    /// Get the enable_reasoning setting
+    pub fn enable_reasoning(&self) -> Option<bool> {
+        self.session_config.enable_reasoning
     }
 
-    /// Set the enable_thinking template parameter
-    /// None = use model's default, Some(true) = enable thinking, Some(false) = disable thinking
-    pub fn set_enable_thinking(&mut self, enabled: Option<bool>) {
-        self.session_mut().set_enable_thinking(enabled);
+    /// Set the enable_reasoning template parameter
+    /// None = use model's default, Some(true) = enable reasoning, Some(false) = disable reasoning
+    pub fn set_enable_reasoning(&mut self, enabled: Option<bool>) {
+        let mut config = self.session_config.clone();
+        config.enable_reasoning = enabled;
+        self.update_session_config(config);
     }
 
     /// Get available agent names
@@ -331,9 +328,9 @@ impl<'a> Chat<'a> {
         self.config.agents.keys().map(|s| s.as_str()).collect()
     }
 
-    /// Get available tool names
-    pub fn available_tool_names(&self) -> Vec<&str> {
-        self.available_tools.keys().copied().collect()
+    /// Get available tool names (all tools from registry, not just active ones)
+    pub fn available_tool_names(&self) -> Vec<String> {
+        self.tool_registry.list()
     }
 
     /// Get available agents with their sources
@@ -374,34 +371,55 @@ impl<'a> Chat<'a> {
 
     /// Gets the tools available for the current chat session.
     pub fn tools(&self) -> Vec<Arc<dyn Tool>> {
-        self.session().tools()
+        self.session_config.tools.clone()
+    }
+
+    /// Gets the tools for the current chat session.
+    pub fn session_tools(&self) -> &[Arc<dyn Tool>] {
+        &self.session_config.tools
     }
 
     /// Sets the tools available for the current chat session.
     pub async fn set_tools(&mut self, tool_names: &[String]) -> Result<()> {
-        let mut tools = Vec::new();
-        for name in tool_names {
-            let tool = self
-                .available_tools
-                .get(name.as_str())
-                .ok_or_else(|| anyhow::anyhow!("Tool not found or not available: {}", name))?;
-            tools.push(tool.clone());
+        let tools = self.tool_registry.tools_for(tool_names);
+
+        if tools.len() != tool_names.len() {
+            let missing: Vec<_> = tool_names
+                .iter()
+                .filter(|name| self.tool_registry.get(name).is_none())
+                .collect();
+            anyhow::bail!("Tools not found or not available: {:?}", missing);
         }
 
-        // Update the session with the new tools
-        self.session_mut().set_tools(tools)?;
+        // Update current agent's session tools to keep it in sync
+        self.current_agent
+            .set_session_tools(Some(tool_names.to_vec()));
 
+        let mut config = self.session_config.clone();
+        config.tools = tools;
+        self.update_session_config(config);
         Ok(())
     }
 
     /// Get all messages from the session
     pub fn get_all_messages(&self) -> Vec<ChatMessage> {
-        self.session().all_messages()
+        self.session().messages()
+    }
+
+    /// Returns true if the model was reset during the last clear() call.
+    #[cfg(test)]
+    pub fn was_model_reset(&self) -> bool {
+        self.session().was_model_reset()
     }
 
     /// Retrieves the last message from the assistant in the conversation history.
     pub fn get_last_assistant_message(&self) -> Option<ChatMessage> {
-        self.session().last_assistant_message()
+        self.session()
+            .messages()
+            .iter()
+            .rev()
+            .find(|m| m.sender == arey_core::completion::SenderType::Assistant)
+            .cloned()
     }
 
     /// Adds messages to the conversation history.
@@ -415,7 +433,7 @@ impl<'a> Chat<'a> {
 
     /// Clears the conversation history of the session.
     pub async fn clear_messages(&mut self) {
-        if let Err(e) = self.session_mut().clear_history().await {
+        if let Err(e) = self.session_mut().clear().await {
             eprintln!("Failed to clear history: {}", e);
         }
     }
@@ -424,7 +442,7 @@ impl<'a> Chat<'a> {
     pub async fn stream_response(
         &mut self,
         cancel_token: CancellationToken,
-    ) -> Result<BoxStream<'_, Result<Completion>>> {
+    ) -> Result<BoxStream<'_, Result<SessionEvent>>> {
         // Use the current profile (either session override or agent default)
         let profile = self
             .current_profile()
@@ -507,15 +525,38 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct OtherMockTool;
+
+    #[async_trait]
+    impl Tool for OtherMockTool {
+        fn name(&self) -> String {
+            "other_mock_tool".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Another mock tool for testing".to_string()
+        }
+
+        fn parameters(&self) -> Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn execute(&self, _input: &Value) -> Result<Value, ToolError> {
+            Ok(json!("Other mock tool executed"))
+        }
+    }
+
     #[tokio::test]
     async fn test_chat_new() -> Result<()> {
         let server = MockServer::start().await;
         let config = get_test_config(&server).await?;
         let mock_tool: Arc<dyn Tool> = Arc::new(MockTool);
-        let available_tools = HashMap::from([("mock_tool", mock_tool)]);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool)?;
 
         // Test with existing model, should use default agent from config
-        let mut chat = Chat::new(&config, Some("test-model".to_string()), available_tools)?;
+        let mut chat = Chat::new(&config, Some("test-model".to_string()), tool_registry)?;
 
         chat.load_session().await?;
 
@@ -525,6 +566,30 @@ mod tests {
         assert_eq!(name, "precise");
         assert_eq!(profile_config.temperature, 0.3);
         assert_eq!(profile_config.top_k, 20);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_available_tool_names_returns_all_registry_tools() -> Result<()> {
+        let server = MockServer::start().await;
+        let config = get_test_config(&server).await?;
+
+        // Create registry with multiple tools
+        let mock_tool1: Arc<dyn Tool> = Arc::new(MockTool);
+        let mock_tool2: Arc<dyn Tool> = Arc::new(OtherMockTool);
+        let mut tool_registry = ToolRegistry::new();
+        tool_registry.register(mock_tool1)?;
+        tool_registry.register(mock_tool2)?;
+
+        // Chat with empty effective_tools (no tools enabled for agent)
+        let chat = Chat::new(&config, Some("test-model".to_string()), tool_registry)?;
+
+        // available_tool_names should return ALL tools from registry, not just active ones
+        let available = chat.available_tool_names();
+        assert_eq!(available.len(), 2);
+        assert!(available.contains(&"mock_tool".to_string()));
+        assert!(available.contains(&"other_mock_tool".to_string()));
 
         Ok(())
     }

--- a/crates/arey/src/svc/play.rs
+++ b/crates/arey/src/svc/play.rs
@@ -3,11 +3,10 @@ use arey_core::{
     completion::{CancellationToken, ChatMessage, Completion, CompletionMetrics, SenderType},
     config::{AreyConfigError, Config},
     model::ModelConfig,
-    session::Session,
+    session::{Session, SessionConfig, SessionEvent},
 };
 use chrono::Local;
-#[allow(unused_imports)]
-use futures::{Stream, StreamExt};
+use futures::{StreamExt, stream::BoxStream};
 use markdown::{Constructs, ParseOptions, to_mdast};
 use serde_yaml::Value;
 use std::{
@@ -163,7 +162,8 @@ impl PlayFile {
                 AreyConfigError::Config("Missing model configuration".to_string())
             })?;
 
-            let session = Session::new(model_config.clone(), "")?;
+            let session_config = SessionConfig::default();
+            let session = Session::new(model_config.clone(), session_config)?;
 
             // TODO: Apply model_settings overrides
             self.session = Some(session);
@@ -174,7 +174,7 @@ impl PlayFile {
     /// Generates a response based on the prompt in the play file.
     ///
     /// It returns a stream of `Completion` events.
-    pub async fn generate(&mut self) -> Result<impl Stream<Item = Result<Completion>>> {
+    pub async fn generate(&mut self) -> Result<BoxStream<'_, Result<Completion>>> {
         self.ensure_session().await?;
         let session = self.session.as_mut().unwrap();
         let prompt = self.prompt.clone();
@@ -201,7 +201,42 @@ impl PlayFile {
 
         let stream = session.generate(settings, cancel_token).await?;
 
-        Ok(stream)
+        let stream = stream.filter_map(|event| async move {
+            match event {
+                Ok(SessionEvent::Token(c)) => Some(Ok(c)),
+                Ok(SessionEvent::CompactionStart) => {
+                    tracing::info!("Context compaction started");
+                    None
+                }
+                Ok(SessionEvent::CompactionEnd { result }) => {
+                    tracing::info!(
+                        "Context compaction completed: {} -> {} messages",
+                        result.original_messages,
+                        result.compacted_messages
+                    );
+                    None
+                }
+                Ok(SessionEvent::ReasoningStart) => {
+                    tracing::debug!("Reasoning started");
+                    None
+                }
+                Ok(SessionEvent::ReasoningEnd { .. }) => {
+                    tracing::debug!("Reasoning ended");
+                    None
+                }
+                Ok(SessionEvent::ToolStart { .. }) => {
+                    tracing::info!("Tool calls started");
+                    None
+                }
+                Ok(SessionEvent::ToolEnd { .. }) => {
+                    tracing::info!("Tool calls completed");
+                    None
+                }
+                Err(e) => Some(Err(e)),
+            }
+        });
+
+        Ok(Box::pin(stream))
     }
 }
 

--- a/crates/arey/src/svc/run.rs
+++ b/crates/arey/src/svc/run.rs
@@ -1,13 +1,12 @@
 use anyhow::{Context, Result};
+use futures::StreamExt;
 use futures::stream::BoxStream;
-use std::sync::Arc;
 
 use arey_core::agent::Agent;
 use arey_core::completion::{CancellationToken, ChatMessage, Completion, SenderType};
 use arey_core::config::Config;
 use arey_core::model::ModelConfig;
-use arey_core::session::Session;
-use arey_core::tools::Tool;
+use arey_core::session::{Session, SessionConfig, SessionEvent};
 
 use crate::ext::get_tools;
 
@@ -51,21 +50,19 @@ impl<'a> Task<'a> {
     /// It should be called before `run`.
     pub async fn load_session(&mut self) -> Result<()> {
         let model_config = self.config.task.model.clone();
-        let system_prompt = &self.current_agent.prompt;
 
-        let mut session =
-            Session::new(model_config, system_prompt).context("Failed to create task session")?;
+        // Get tools from registry based on agent's effective tools
+        let tool_registry = get_tools(self.config).unwrap_or_default();
+        let tools = tool_registry.tools_for(self.current_agent.effective_tools());
 
-        // Get tools for the agent
-        let available_tools = get_tools(self.config).unwrap_or_default();
-        let tools: Vec<Arc<dyn Tool>> = self
-            .current_agent
-            .effective_tools()
-            .iter()
-            .filter_map(|tool_name| available_tools.get(tool_name.as_str()).cloned())
-            .collect();
+        let session_config = SessionConfig {
+            system_prompt: self.current_agent.prompt.clone(),
+            tools,
+            ..Default::default()
+        };
 
-        session.set_tools(tools)?;
+        let session =
+            Session::new(model_config, session_config).context("Failed to create task session")?;
 
         self.session = Some(session);
         Ok(())
@@ -81,10 +78,9 @@ impl<'a> Task<'a> {
     pub async fn load_model(&mut self) -> Result<arey_core::model::ModelMetrics> {
         self.load_session().await?;
 
-        // Return metrics from the session
         self.session
             .as_ref()
-            .and_then(|s| s.metrics().cloned())
+            .map(|s| s.metrics().clone())
             .ok_or_else(|| anyhow::anyhow!("No metrics available"))
     }
 
@@ -115,7 +111,43 @@ impl<'a> Task<'a> {
             .await
             .context("Failed to generate response")?;
 
-        Ok(stream)
+        // Map SessionEvent to Completion
+        let stream = stream.filter_map(|event| async move {
+            match event {
+                Ok(SessionEvent::Token(c)) => Some(Ok(c)),
+                Ok(SessionEvent::CompactionStart) => {
+                    tracing::info!("Context compaction started");
+                    None
+                }
+                Ok(SessionEvent::CompactionEnd { result }) => {
+                    tracing::info!(
+                        "Context compaction completed: {} -> {} messages",
+                        result.original_messages,
+                        result.compacted_messages
+                    );
+                    None
+                }
+                Ok(SessionEvent::ReasoningStart) => {
+                    tracing::debug!("Reasoning started");
+                    None
+                }
+                Ok(SessionEvent::ReasoningEnd { .. }) => {
+                    tracing::debug!("Reasoning ended");
+                    None
+                }
+                Ok(SessionEvent::ToolStart { .. }) => {
+                    tracing::info!("Tool calls started");
+                    None
+                }
+                Ok(SessionEvent::ToolEnd { .. }) => {
+                    tracing::info!("Tool calls completed");
+                    None
+                }
+                Err(e) => Some(Err(e)),
+            }
+        });
+
+        Ok(Box::pin(stream))
     }
 }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,13 +36,14 @@ tracing-subscriber.workspace = true
 notify.workspace = true
 minijinja = { version = "2.18.0", features = ["builtins", "json"] }
 minijinja-contrib = { version = "2.18.0", features = ["pycompat"] }
-llama-cpp-2 = "=0.1.141"
+llama-cpp-2 = "=0.1.143"
 
 [dev-dependencies]
 tempfile = { workspace = true, features = [] }
 wiremock = { workspace = true, features = [] }
 tokio = { version = "1.50", features = ["macros", "rt-multi-thread"] }
 reqwest.workspace = true
+yare.workspace = true
 
 
 [features]

--- a/crates/core/src/completion.rs
+++ b/crates/core/src/completion.rs
@@ -110,11 +110,16 @@ pub struct CacheMetrics {
     pub checkpoint_transition: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CompletionResponse {
     pub text: String,
     pub thought: Option<String>,
     pub tool_calls: Option<Vec<ToolCall>>,
+
+    /// The reason the completion finished.
+    /// Possible values:
+    /// "stop", "length" are supported by all providers.
+    /// "trimmed" is a special internal value indicating the session to trim conversation and retry.
     pub finish_reason: Option<String>,
     pub raw_chunk: Option<String>,
 }

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -1,0 +1,788 @@
+use crate::completion::{ChatMessage, SenderType};
+use anyhow::Result;
+
+const DEFAULT_MAX_CONTEXT_TOKENS: usize = 4096;
+const DEFAULT_CHUNK_SIZE_TOKENS: usize = 1024;
+const DEFAULT_PRESERVE_RECENT_TURNS: usize = 1;
+const COMPACTION_THRESHOLD: f32 = 0.80;
+
+#[derive(Debug, Clone)]
+pub struct CompactionConfig {
+    pub max_context_tokens: usize,
+    pub chunk_size_tokens: usize,
+    pub preserve_recent_turns: usize,
+    pub threshold: f32,
+}
+
+impl Default for CompactionConfig {
+    fn default() -> Self {
+        Self {
+            max_context_tokens: DEFAULT_MAX_CONTEXT_TOKENS,
+            chunk_size_tokens: DEFAULT_CHUNK_SIZE_TOKENS,
+            preserve_recent_turns: DEFAULT_PRESERVE_RECENT_TURNS,
+            threshold: COMPACTION_THRESHOLD,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompactionResult {
+    pub original_messages: usize,
+    pub compacted_messages: usize,
+    pub summary_tokens: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageChunk {
+    pub messages: Vec<ChatMessage>,
+    pub _token_estimate: usize,
+}
+
+#[derive(Clone)]
+pub struct Context {
+    all_messages: Vec<(ChatMessage, Option<usize>)>,
+    messages: Vec<(ChatMessage, Option<usize>)>,
+    context_size: usize,
+    system_prompt: String,
+    config: CompactionConfig,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            all_messages: Vec::new(),
+            messages: Vec::new(),
+            context_size: DEFAULT_MAX_CONTEXT_TOKENS,
+            system_prompt: String::new(),
+            config: CompactionConfig::default(),
+        }
+    }
+}
+
+impl Context {
+    pub fn new(context_size: usize) -> Self {
+        Self {
+            all_messages: Vec::new(),
+            messages: Vec::new(),
+            context_size,
+            system_prompt: String::new(),
+            config: CompactionConfig::default(),
+        }
+    }
+
+    pub fn with_system(mut self, prompt: String) -> Self {
+        self.system_prompt = prompt;
+        self
+    }
+
+    pub fn with_messages(mut self, messages: Vec<(ChatMessage, Option<usize>)>) -> Self {
+        self.all_messages = messages.clone();
+        self.messages = messages;
+        self
+    }
+
+    // ----- Messages management -----
+
+    pub fn add_message(&mut self, message: ChatMessage) -> Result<()> {
+        // Update both all_messages (archive) and messages (working copy)
+        self.all_messages.push((message.clone(), None));
+
+        if message.sender != SenderType::Assistant {
+            self.messages.push((message, None));
+            return Ok(());
+        }
+
+        let messages = &mut self.messages;
+
+        let mut known_prompt_tokens: usize = 0;
+        let mut unknown_message_indices = Vec::new();
+        let mut total_unknown_chars = 0;
+
+        for (i, (msg, count)) in messages.iter().enumerate() {
+            if let Some(count) = *count {
+                known_prompt_tokens += count;
+            } else {
+                unknown_message_indices.push(i);
+                total_unknown_chars += msg.text.len();
+            }
+        }
+
+        let metrics = if let Some(m) = message.metrics.clone() {
+            m
+        } else {
+            self.messages.push((message, None));
+            return Ok(());
+        };
+
+        let new_tokens = (metrics.prompt_tokens as usize).saturating_sub(known_prompt_tokens);
+
+        if !unknown_message_indices.is_empty() {
+            if total_unknown_chars > 0 {
+                let mut distributed_tokens: usize = 0;
+                let last_index = unknown_message_indices.len() - 1;
+
+                for (i, msg_idx) in unknown_message_indices.iter().enumerate() {
+                    let msg_chars = messages[*msg_idx].0.text.len();
+                    let msg_tokens = if i == last_index {
+                        new_tokens.saturating_sub(distributed_tokens)
+                    } else {
+                        (new_tokens * msg_chars) / total_unknown_chars
+                    };
+                    messages[*msg_idx].1 = Some(msg_tokens);
+                    distributed_tokens += msg_tokens;
+                }
+            } else if unknown_message_indices.len() == 1 {
+                messages[unknown_message_indices[0]].1 = Some(new_tokens);
+            }
+        }
+
+        messages.push((message, Some(metrics.completion_tokens as usize)));
+        Ok(())
+    }
+
+    pub fn messages_tuple(&self) -> &[(ChatMessage, Option<usize>)] {
+        &self.messages
+    }
+
+    pub fn clear(&mut self) {
+        self.all_messages.clear();
+        self.messages.clear();
+    }
+
+    pub fn trim(&mut self, force: bool) -> Result<bool> {
+        // Force trim: OOM recovery - keep last 50%
+        if force {
+            let keep_count = self.messages.len().div_ceil(2);
+            if keep_count < self.messages.len() {
+                let original_len = self.messages.len();
+                let kept: Vec<_> = self.messages.iter().skip(keep_count).cloned().collect();
+                self.messages = kept;
+                tracing::debug!(
+                    "Force trim: removed {} messages, kept {}",
+                    original_len - self.messages.len(),
+                    self.messages.len()
+                );
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+
+        // Normal trim: fit to budget
+        let safety_margin = Self::safety_margin(self.context_size);
+        let system_prompt_tokens = self.system_prompt.len() / 4 + 50;
+        let available_for_messages = self
+            .context_size
+            .saturating_sub(safety_margin)
+            .saturating_sub(system_prompt_tokens);
+
+        let total_tokens: usize = self
+            .messages
+            .iter()
+            .map(|(msg, count)| count.unwrap_or_else(|| self.estimate_tokens(msg)))
+            .sum();
+
+        if total_tokens <= available_for_messages {
+            return Ok(false);
+        }
+
+        if let Some((last_msg, count)) = self.messages.last() {
+            let last_tokens = count.unwrap_or_else(|| self.estimate_tokens(last_msg));
+            if last_tokens > available_for_messages {
+                return Err(anyhow::anyhow!(
+                    "Last message ({} tokens, {} chars) exceeds available context budget ({} tokens)",
+                    last_tokens,
+                    last_msg.text.len(),
+                    available_for_messages
+                ));
+            }
+        }
+
+        let mut trimmed = Vec::new();
+        let mut used_tokens = 0;
+        let mut i = self.messages.len();
+
+        while i > 0 {
+            let block_start = self.find_block_start(&self.messages, i);
+            let block_tokens: usize = self.messages[block_start..i]
+                .iter()
+                .map(|(msg, count)| count.unwrap_or_else(|| self.estimate_tokens(msg)))
+                .sum();
+
+            if used_tokens + block_tokens <= available_for_messages {
+                used_tokens += block_tokens;
+                trimmed.splice(
+                    0..0,
+                    self.messages[block_start..i]
+                        .iter()
+                        .map(|(msg, _)| msg.clone()),
+                );
+                i = block_start;
+            } else {
+                let trimmed_block = self.trim_oversized_block(
+                    &self.messages[block_start..i],
+                    available_for_messages.saturating_sub(used_tokens),
+                )?;
+                if !trimmed_block.is_empty() {
+                    trimmed.splice(0..0, trimmed_block);
+                }
+                break;
+            }
+        }
+
+        let original_count = self.messages.len();
+        self.messages = trimmed.into_iter().map(|m| (m, None)).collect();
+        let did_trim = self.messages.len() < original_count;
+
+        Ok(did_trim)
+    }
+
+    fn find_block_start(&self, messages: &[(ChatMessage, Option<usize>)], end_idx: usize) -> usize {
+        if end_idx == 0 {
+            return 0;
+        }
+
+        let mut idx = end_idx - 1;
+        while idx > 0 {
+            if messages[idx].0.sender == SenderType::User {
+                return idx;
+            }
+            idx -= 1;
+        }
+        0
+    }
+
+    fn trim_oversized_block(
+        &self,
+        block_messages: &[(ChatMessage, Option<usize>)],
+        available_tokens: usize,
+    ) -> Result<Vec<ChatMessage>> {
+        let mut final_messages = Vec::new();
+        let mut used_tokens = 0;
+
+        for (msg, count) in block_messages.iter() {
+            let mut msg_to_add = msg.clone();
+            let mut tokens = count.unwrap_or_else(|| self.estimate_tokens(&msg_to_add));
+
+            if used_tokens + tokens > available_tokens {
+                if msg_to_add.sender == SenderType::Tool {
+                    let budget_for_this_msg = available_tokens.saturating_sub(used_tokens);
+                    let chars_to_keep = budget_for_this_msg * 4;
+                    if msg_to_add.text.chars().count() > chars_to_keep {
+                        let truncated: String =
+                            msg_to_add.text.chars().take(chars_to_keep).collect();
+                        msg_to_add.text = truncated;
+                        msg_to_add.text.push_str("\n... [truncated]");
+                        tokens = budget_for_this_msg;
+                    } else {
+                        used_tokens += tokens;
+                        final_messages.push(msg_to_add);
+                        continue;
+                    }
+                } else {
+                    let preview: String = msg_to_add.text.chars().take(50).collect();
+                    return Err(anyhow::anyhow!(
+                        "Message (type: {:?}, preview: \"{}...\", {} chars) exceeds available \
+                         budget ({} tokens). Only Tool messages can be truncated.",
+                        msg_to_add.sender,
+                        preview,
+                        msg_to_add.text.len(),
+                        available_tokens
+                    ));
+                }
+            }
+
+            used_tokens += tokens;
+            final_messages.push(msg_to_add);
+        }
+
+        Ok(final_messages)
+    }
+
+    fn safety_margin(context_size: usize) -> usize {
+        if context_size <= 640 {
+            context_size / 20
+        } else {
+            (context_size / 10).min(512)
+        }
+    }
+
+    fn estimate_tokens(&self, message: &ChatMessage) -> usize {
+        let base = message.text.len() / 4;
+        let overhead = 50;
+
+        let tool_overhead = message.tools.as_ref().map(|t| t.len() * 100).unwrap_or(0);
+
+        base + overhead + tool_overhead
+    }
+
+    pub fn needs_compaction(&self, messages: &[(ChatMessage, Option<usize>)]) -> bool {
+        let total: usize = {
+            messages
+                .iter()
+                .map(|(msg, count)| count.unwrap_or_else(|| self.estimate_tokens(msg)))
+                .sum()
+        };
+        let current_threshold = total as f32 / self.config.max_context_tokens as f32;
+        current_threshold > self.config.threshold
+    }
+
+    fn chunk_messages(&self, messages: &[ChatMessage], target_size: usize) -> Vec<MessageChunk> {
+        if messages.is_empty() {
+            return vec![];
+        }
+
+        let mut chunks = Vec::new();
+        let mut current_chunk: Vec<ChatMessage> = Vec::new();
+        let mut current_tokens = 0;
+
+        for msg in messages {
+            let msg_tokens = self.estimate_tokens(msg);
+
+            if !current_chunk.is_empty() && current_tokens + msg_tokens > target_size {
+                chunks.push(MessageChunk {
+                    messages: std::mem::take(&mut current_chunk),
+                    _token_estimate: current_tokens,
+                });
+                current_tokens = 0;
+            }
+
+            current_chunk.push(msg.clone());
+            current_tokens += msg_tokens;
+        }
+
+        if !current_chunk.is_empty() {
+            chunks.push(MessageChunk {
+                messages: current_chunk,
+                _token_estimate: current_tokens,
+            });
+        }
+
+        chunks
+    }
+
+    // TODO: Implement compact() - LLM summarization
+    // - Split messages into recent + older (preserve last N turns via config.preserve_recent_turns)
+    // - Archive older messages to all_messages
+    // - Call LLM with summarization prompt (see data/prompt/summarize.md)
+    // - Replace older with summary exchange in messages working copy
+    pub fn compact(&mut self) -> CompactionResult {
+        let original_count = self.messages.len();
+
+        if self.messages.is_empty() || !self.needs_compaction(&self.messages) {
+            return CompactionResult {
+                original_messages: original_count,
+                compacted_messages: original_count,
+                summary_tokens: 0,
+            };
+        }
+
+        let (recent, older) = {
+            let this = &self;
+            let messages: &[(ChatMessage, Option<usize>)] = &self.messages;
+            let preserve_count = this.config.preserve_recent_turns * 2;
+
+            if messages.len() <= preserve_count {
+                (messages.to_vec(), vec![])
+            } else {
+                let split_idx = messages.len() - preserve_count;
+                (
+                    messages[split_idx..].to_vec(),
+                    messages[..split_idx].to_vec(),
+                )
+            }
+        };
+
+        if older.is_empty() {
+            return CompactionResult {
+                original_messages: original_count,
+                compacted_messages: original_count,
+                summary_tokens: 0,
+            };
+        }
+
+        // Archive older messages to all_messages (for future retrieval)
+        self.all_messages.extend(older.clone());
+
+        // TODO: Call LLM to summarize older messages
+        // For now, just keep recent messages (placeholder for LLM summarization)
+        let older_messages: Vec<ChatMessage> = older.iter().map(|(m, _)| m.clone()).collect();
+        let chunks = self.chunk_messages(&older_messages, self.config.chunk_size_tokens);
+
+        let mut summaries: Vec<ChatMessage> = Vec::new();
+
+        for chunk in chunks {
+            summaries.extend(chunk.messages);
+        }
+
+        let summary_tokens = {
+            let this = &self;
+            let messages: &[(ChatMessage, Option<usize>)] = &summaries
+                .iter()
+                .map(|m| (m.clone(), None))
+                .collect::<Vec<_>>();
+            messages
+                .iter()
+                .map(|(msg, count)| count.unwrap_or_else(|| this.estimate_tokens(msg)))
+                .sum()
+        };
+
+        self.messages = recent;
+        self.messages
+            .extend(summaries.into_iter().map(|m| (m, None)));
+
+        let compacted_count = self.messages.len();
+
+        CompactionResult {
+            original_messages: original_count,
+            compacted_messages: compacted_count,
+            summary_tokens,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completion::SenderType;
+    use crate::tools::ToolCall;
+    use yare::parameterized;
+
+    pub fn new_chat_msg(sender: SenderType, text: &str) -> ChatMessage {
+        ChatMessage {
+            sender,
+            text: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn msg_tuple(msg: ChatMessage) -> (ChatMessage, Option<usize>) {
+        (msg, None)
+    }
+
+    fn new_tool_call(name: &str) -> ToolCall {
+        ToolCall {
+            id: format!("call_{}", name),
+            name: name.to_string(),
+            arguments: "{}".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_new_with_default_context() {
+        let ctx = Context::new(4096);
+        assert!(ctx.messages_tuple().is_empty());
+    }
+
+    #[test]
+    fn test_with_messages() {
+        let msgs = vec![
+            msg_tuple(new_chat_msg(SenderType::User, "Hello")),
+            msg_tuple(new_chat_msg(SenderType::Assistant, "Hi")),
+        ];
+        let ctx = Context::new(4096).with_messages(msgs);
+        assert_eq!(ctx.messages_tuple().len(), 2);
+    }
+
+    #[test]
+    fn test_with_system() {
+        let ctx = Context::new(4096).with_system("You are helpful".into());
+        assert_eq!(ctx.system_prompt, "You are helpful");
+    }
+
+    #[test]
+    fn test_messages_tuple() {
+        let mut ctx = Context::default();
+        ctx.messages
+            .push(msg_tuple(new_chat_msg(SenderType::User, "Test")));
+        let tuple = ctx.messages_tuple();
+        assert_eq!(tuple.len(), 1);
+        assert_eq!(tuple[0].0.text, "Test");
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut ctx = Context::default();
+        ctx.messages
+            .push(msg_tuple(new_chat_msg(SenderType::User, "Test")));
+        ctx.clear();
+        assert!(ctx.messages_tuple().is_empty());
+    }
+
+    #[parameterized(
+        small_context = { 640, 32 },
+        medium_context = { 4096, 409 },
+        large_context = { 8192, 512 },
+    )]
+    fn test_safety_margin(context_size: usize, expected: usize) {
+        assert_eq!(Context::safety_margin(context_size), expected);
+    }
+
+    #[test]
+    fn test_add_message_with_tools() {
+        let mut ctx = Context::default();
+
+        let user_msg = ChatMessage {
+            sender: SenderType::User,
+            text: "Use the search tool".to_string(),
+            ..Default::default()
+        };
+        let _ = ctx.add_message(user_msg);
+
+        let tool_call = new_tool_call("search");
+        let assistant_msg = ChatMessage {
+            sender: SenderType::Assistant,
+            text: "I'll search for that".to_string(),
+            tools: Some(vec![tool_call]),
+            metrics: Some(crate::completion::CompletionMetrics {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let _ = ctx.add_message(assistant_msg);
+
+        assert_eq!(ctx.messages_tuple().len(), 2);
+        assert_eq!(ctx.messages_tuple()[1].0.tools.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_add_message_syncs_both_fields() {
+        let mut ctx = Context::new(4096);
+
+        let msg = new_chat_msg(SenderType::User, "Test");
+        ctx.add_message(msg).unwrap();
+
+        assert_eq!(ctx.messages_tuple().len(), 1);
+        assert!(!ctx.all_messages.is_empty());
+    }
+
+    #[test]
+    fn test_builder_chain() {
+        let msgs = vec![msg_tuple(new_chat_msg(SenderType::User, "Hello"))];
+        let ctx = Context::new(4096)
+            .with_system("You are helpful".into())
+            .with_messages(msgs);
+
+        assert_eq!(ctx.system_prompt, "You are helpful");
+        assert_eq!(ctx.messages_tuple().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod trim_tests {
+    use super::*;
+    use tests::{msg_tuple, new_chat_msg};
+    use yare::parameterized;
+
+    #[test]
+    fn test_trim_messages_extremely_large_tool_result() {
+        let mut ctx = Context::new(100000);
+
+        ctx.messages = vec![
+            msg_tuple(new_chat_msg(SenderType::User, "Q1")),
+            msg_tuple(new_chat_msg(SenderType::Assistant, "A1")),
+            msg_tuple(new_chat_msg(SenderType::Tool, &"Y".repeat(50000))),
+        ];
+
+        ctx.trim(false).unwrap();
+        assert!(!ctx.messages_tuple().is_empty());
+    }
+
+    #[test]
+    fn test_trim_oversized_block_multibyte_chars() {
+        let mut ctx = Context::new(5000);
+
+        let long_string = "a".repeat(510) + "€"; // € is 3 bytes
+
+        ctx.messages = vec![
+            (new_chat_msg(SenderType::User, "Q1"), None),
+            (new_chat_msg(SenderType::Tool, &long_string), None),
+        ];
+
+        ctx.trim(false).unwrap();
+        // Just verify no panic on multibyte
+    }
+
+    #[test]
+    fn test_trim_last_message_too_large() {
+        let mut ctx = Context::new(500);
+
+        ctx.messages = vec![(new_chat_msg(SenderType::User, &"X".repeat(2000)), None)];
+
+        let result = ctx.trim(false);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("exceeds available context budget"));
+    }
+
+    #[parameterized(
+        user_message_too_large = { 500, vec![(SenderType::User, "X".repeat(2000))], true },
+        assistant_and_user_too_large = { 500, vec![(SenderType::User, "X".repeat(2000)), (SenderType::Assistant, "Response".to_string())], true },
+    )]
+    fn test_trim_error_cases(
+        context_size: usize,
+        messages: Vec<(SenderType, String)>,
+        expect_error: bool,
+    ) {
+        let mut ctx = Context::new(context_size);
+        ctx.messages = messages
+            .into_iter()
+            .map(|(s, t)| (new_chat_msg(s, &t), None))
+            .collect();
+
+        let result = ctx.trim(false);
+        if expect_error {
+            assert!(result.is_err(), "Expected error but got success");
+        } else {
+            assert!(
+                result.is_ok(),
+                "Expected success but got error: {:?}",
+                result.err()
+            );
+        }
+    }
+
+    #[parameterized(
+        empty_messages = { 4096, vec![] },
+        simple_conversation = { 10000, vec![(SenderType::User, "Hi".to_string()), (SenderType::Assistant, "Hello".to_string())] },
+    )]
+    fn test_trim_success_cases(context_size: usize, messages: Vec<(SenderType, String)>) {
+        let mut ctx = Context::new(context_size);
+        ctx.messages = messages
+            .into_iter()
+            .map(|(s, t)| (new_chat_msg(s, &t), None))
+            .collect();
+
+        let result = ctx.trim(false);
+        assert!(
+            result.is_ok(),
+            "Expected success but got error: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_trim_empty_prompt_and_messages() {
+        let mut ctx = Context::new(4096);
+
+        let result = ctx.trim(false);
+        assert!(result.is_ok());
+        assert!(!result.unwrap()); // no trim performed
+    }
+
+    #[test]
+    fn test_trim_force_oom_recovery() {
+        let mut ctx = Context::new(1000);
+
+        ctx.messages = vec![
+            msg_tuple(new_chat_msg(SenderType::User, "Message 1")),
+            msg_tuple(new_chat_msg(SenderType::Assistant, "Response 1")),
+            msg_tuple(new_chat_msg(SenderType::User, "Message 2")),
+            msg_tuple(new_chat_msg(SenderType::Assistant, "Response 2")),
+            msg_tuple(new_chat_msg(SenderType::User, "Message 3")),
+        ];
+
+        let original_count = ctx.messages.len();
+        assert!(original_count > 2);
+
+        let result = ctx.trim(true);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+
+        let remaining = ctx.messages.len();
+        assert!(remaining < original_count);
+    }
+
+    #[test]
+    fn test_trim_with_system_prompt() {
+        let mut ctx = Context::new(2000);
+        ctx.system_prompt = "You are a helpful assistant with a very long system prompt that takes up context tokens".to_string();
+
+        ctx.messages = vec![msg_tuple(new_chat_msg(SenderType::User, "Short question"))];
+
+        let result = ctx.trim(false);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_trim_non_tool_message_exceeds_budget() {
+        let mut ctx = Context::new(500);
+
+        ctx.messages = vec![(new_chat_msg(SenderType::User, &"X".repeat(5000)), None)];
+
+        let result = ctx.trim(false);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        println!("Error: {}", err);
+        assert!(err.to_string().contains("exceeds available context budget"));
+    }
+}
+
+#[cfg(test)]
+mod compact_tests {
+    use super::*;
+    use tests::{msg_tuple, new_chat_msg};
+    use yare::parameterized;
+
+    #[parameterized(
+        empty_messages = { vec![], 0.0 },
+        under_threshold = { vec![msg_tuple(new_chat_msg(SenderType::User, "Hi"))], 0.3 },
+        over_threshold = { vec![msg_tuple(new_chat_msg(SenderType::User, &"X".repeat(10000)))], 0.9 },
+    )]
+    fn test_needs_compaction(messages: Vec<(ChatMessage, Option<usize>)>, usage: f32) {
+        let mut ctx = Context::new(10000);
+        ctx.messages = messages.clone();
+        ctx.config.threshold = 0.8;
+        ctx.config.max_context_tokens = if messages.is_empty() {
+            10000
+        } else {
+            messages.len() * 100
+        };
+
+        let result = ctx.needs_compaction(&messages);
+        if usage > 0.8 {
+            assert!(result, "Expected compaction needed at usage {}", usage);
+        } else {
+            assert!(!result, "Expected no compaction at usage {}", usage);
+        }
+    }
+
+    #[test]
+    fn test_needs_compaction_at_exact_threshold() {
+        let mut ctx = Context::new(10000);
+        ctx.config.threshold = 0.8;
+        ctx.config.max_context_tokens = 1000;
+
+        let msg_text = "X".repeat(800);
+        ctx.messages = vec![msg_tuple(new_chat_msg(SenderType::User, &msg_text))];
+
+        let result = ctx.needs_compaction(&ctx.messages);
+        assert!(
+            !result,
+            "Should NOT need compaction at exactly 0.8 threshold"
+        );
+    }
+
+    #[parameterized(
+        noop_when_empty = { vec![], true },
+        noop_when_under_threshold = { vec![msg_tuple(new_chat_msg(SenderType::User, "Hi"))], true },
+        compact_when_over_threshold = { vec![msg_tuple(new_chat_msg(SenderType::User, &"X".repeat(10000)))], false },
+    )]
+    fn test_compact(messages: Vec<(ChatMessage, Option<usize>)>, expect_noop: bool) {
+        let mut ctx = Context::new(10000);
+        ctx.messages = messages.clone();
+        ctx.config.threshold = 0.8;
+        ctx.config.max_context_tokens = 10000;
+        ctx.config.preserve_recent_turns = 1;
+        ctx.config.chunk_size_tokens = 1024;
+
+        let result = ctx.compact();
+        if expect_noop {
+            assert_eq!(result.compacted_messages, result.original_messages);
+        } else {
+            assert!(result.compacted_messages <= result.original_messages);
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,7 +4,9 @@ pub mod provider;
 pub mod agent;
 pub mod completion;
 pub mod config;
+mod context; // Internal - used by Session, not exported publicly
 pub mod model;
+pub mod registry;
 pub mod session;
 pub mod tools;
 

--- a/crates/core/src/model.rs
+++ b/crates/core/src/model.rs
@@ -125,9 +125,60 @@ impl ModelProvider {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ModelMetrics {
+    /// Initialization latency in milliseconds
     pub init_latency_ms: f32,
+
+    /// Number of CPU threads detected
+    pub cpu_threads: Option<usize>,
+
+    /// List of GPU devices detected
+    pub gpu_devices: Option<Vec<GpuDeviceInfo>>,
+
+    /// Context window size (auto-tuned)
+    pub n_ctx: Option<u32>,
+
+    /// Logical batch size for prompt processing (auto-tuned)
+    pub n_batch: Option<u32>,
+
+    /// Physical batch size for prompt processing (auto-tuned)
+    pub n_ubatch: Option<u32>,
+
+    /// Number of GPU layers to offload (auto-tuned)
+    pub n_gpu_layers: Option<i32>,
+
+    /// Number of threads for inference (auto-tuned)
+    pub n_threads: Option<i32>,
+
+    /// Whether flash attention is enabled (auto-tuned)
+    pub flash_attention: Option<bool>,
+
+    /// Model parameter count in billions (from GGUF metadata)
+    pub model_params_billions: Option<f64>,
+
+    /// Number of layers in the model (from GGUF metadata)
+    pub model_layers: Option<u32>,
+
+    /// Quantization type (from GGUF metadata, e.g., "Q4_K_M")
+    pub quantization: Option<String>,
+
+    /// Model's trained context window size (from GGUF metadata)
+    pub model_n_ctx_train: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct GpuDeviceInfo {
+    /// Device name (e.g., "Vulkan0", "CUDA0")
+    pub name: String,
+    /// Backend name (e.g., "Vulkan", "CUDA", "CPU")
+    pub backend: String,
+    /// Device type (e.g., "Cpu", "Gpu", "IntegratedGpu")
+    pub device_type: String,
+    /// Total memory in MB
+    pub memory_total_mb: Option<usize>,
+    /// Free/available memory in MB
+    pub memory_free_mb: Option<usize>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/src/provider/gguf/mod.rs
+++ b/crates/core/src/provider/gguf/mod.rs
@@ -4,8 +4,12 @@ pub use model::GgufBaseModel;
 
 mod checkpoint;
 mod model;
+mod system;
 mod template;
 mod tool;
 
+pub use system::{
+    ComputeParams, ConfigOverrides, compute_params, detect_system_info, flash_attention_policy,
+};
 pub use template::apply_chat_template;
 pub use tool::{TemplatePatterns, ToolCallParser, get_tool_call_regexes};

--- a/crates/core/src/provider/gguf/model.rs
+++ b/crates/core/src/provider/gguf/model.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use llama_cpp_2::{
     LogOptions,
+    context::LlamaContext,
     context::params::LlamaContextParams,
     llama_backend::LlamaBackend,
     llama_batch::LlamaBatch,
@@ -35,7 +36,12 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::debug;
 
+use crate::model::{GpuDeviceInfo, ModelMetrics};
 use crate::provider::gguf::checkpoint::{CheckpointManager, TransitionType};
+use crate::provider::gguf::system::{
+    ConfigOverrides, MemoryTrimmedError, Quantization, compute_params, detect_system_info,
+    flash_attention_policy, handle_memory_error,
+};
 use crate::provider::gguf::template::{ToolCallParser, apply_chat_template, get_tool_call_regexes};
 
 static GGUF_BACKEND: once_cell::sync::Lazy<Arc<LlamaBackend>> = once_cell::sync::Lazy::new(|| {
@@ -45,6 +51,8 @@ static GGUF_BACKEND: once_cell::sync::Lazy<Arc<LlamaBackend>> = once_cell::sync:
 pub struct GgufBaseModel {
     request_tx: mpsc::Sender<Request>,
     _thread_guard: Arc<ThreadGuard>,
+    /// Model metrics including system info and auto-tuned parameters
+    metrics: Arc<std::sync::Mutex<ModelMetrics>>,
 }
 
 /// Load status for tracking model loading progress.
@@ -109,7 +117,11 @@ impl GgufBaseModel {
         let (request_tx, request_rx) = mpsc::channel::<Request>(4);
         let (status_tx, status_rx) = mpsc::channel::<LoadStatus>(4);
 
+        // Shared metrics that will be populated by the model thread
+        let metrics = Arc::new(std::sync::Mutex::new(ModelMetrics::default()));
+
         let backend = GGUF_BACKEND.clone();
+        let metrics_clone = metrics.clone();
         let thread = thread::Builder::new()
             .name(format!("gguf-model-{}", model_config.key))
             .spawn(move || {
@@ -119,6 +131,7 @@ impl GgufBaseModel {
                     model_config,
                     request_rx,
                     Some(status_tx),
+                    metrics_clone,
                 );
             })
             .context("failed to spawn GGUF model thread")?;
@@ -148,6 +161,7 @@ impl GgufBaseModel {
             _thread_guard: Arc::new(ThreadGuard {
                 _handle: Some(thread),
             }),
+            metrics,
         })
     }
 }
@@ -155,7 +169,7 @@ impl GgufBaseModel {
 #[async_trait]
 impl CompletionModel for GgufBaseModel {
     fn metrics(&self) -> crate::model::ModelMetrics {
-        crate::model::ModelMetrics::default()
+        self.metrics.lock().unwrap().clone()
     }
 
     async fn complete(
@@ -179,8 +193,7 @@ impl CompletionModel for GgufBaseModel {
             .unwrap_or(0);
 
         let messages: Vec<ChatMessage> = messages.to_vec();
-        let tools: Option<Vec<_>> =
-            tools.map(|t| t.iter().map(|tool| tool.clone().into()).collect());
+        let tools: Option<Vec<_>> = tools.map(|t| t.iter().map(|t| t.clone().into()).collect());
 
         let request = Request {
             messages,
@@ -238,6 +251,7 @@ fn run_event_loop(
     model_config: ModelConfig,
     mut request_rx: mpsc::Receiver<Request>,
     status_sender: Option<LoadStatusSender>,
+    metrics: Arc<std::sync::Mutex<ModelMetrics>>,
 ) {
     send_logs_to_tracing(LogOptions::default());
 
@@ -246,14 +260,9 @@ fn run_event_loop(
         .as_ref()
         .map(|s| s.try_send(LoadStatus::Loading));
 
-    let n_ctx = model_config.get_setting::<u32>("n_ctx").unwrap_or(4096);
-    let n_batch = model_config.get_setting::<u32>("n_batch").unwrap_or(512);
-    let n_gpu_layers = model_config.get_setting::<u32>("n_gpu_layers").unwrap_or(0);
-
-    let model_params = LlamaModelParams::default().with_n_gpu_layers(n_gpu_layers);
-    let context_params = LlamaContextParams::default()
-        .with_n_ctx(NonZeroU32::new(n_ctx))
-        .with_n_batch(n_batch);
+    // Get config overrides - only n_gpu_layers needed for initial model load
+    let n_gpu_layers_config = model_config.get_setting::<i32>("n_gpu_layers").unwrap_or(0) as u32;
+    let model_params = LlamaModelParams::default().with_n_gpu_layers(n_gpu_layers_config);
 
     let model = match LlamaModel::load_from_file(&backend, &model_path, &model_params) {
         Ok(m) => m,
@@ -265,6 +274,107 @@ fn run_event_loop(
             return;
         }
     };
+
+    // Get model's trained context size from GGUF metadata
+    let model_n_ctx_train = model.n_ctx_train();
+
+    // Get model parameter count for GPU layer calculation
+    let model_params_count = model.n_params() as f64 / 1e9; // Convert to billions
+
+    // Get model layer count
+    let model_layers = model.n_layer();
+
+    // Get file type to detect quantization
+    let file_type = model.meta_val_str("general.file_type").ok();
+    let quantization = file_type
+        .as_deref()
+        .map(Quantization::from_file_type)
+        .unwrap_or(Quantization::Unknown);
+
+    tracing::debug!(
+        model_params_billions = model_params_count,
+        model_layers = model_layers,
+        file_type = file_type.as_deref(),
+        quantization = ?quantization,
+        "model quantization info"
+    );
+
+    // Detect system and compute optimal parameters
+    let system_info = detect_system_info();
+
+    // Build config overrides from model_config
+    let overrides = ConfigOverrides {
+        n_ctx: model_config.get_setting::<u32>("n_ctx"),
+        n_batch: model_config.get_setting::<u32>("n_batch"),
+        n_ubatch: model_config.get_setting::<u32>("n_ubatch"),
+        n_gpu_layers: model_config.get_setting::<i32>("n_gpu_layers"),
+        n_threads: model_config.get_setting::<i32>("n_threads"),
+        flash_attention: model_config.get_setting::<bool>("flash_attention"),
+    };
+
+    let computed = compute_params(
+        &system_info,
+        model_n_ctx_train,
+        model_layers,
+        model_params_count,
+        quantization,
+        &overrides,
+    );
+
+    tracing::info!(
+        model_n_ctx_train = model_n_ctx_train,
+        computed_n_ctx = computed.n_ctx,
+        computed_n_batch = computed.n_batch,
+        computed_n_ubatch = computed.n_ubatch,
+        computed_n_gpu_layers = computed.n_gpu_layers,
+        computed_n_threads = computed.n_threads,
+        flash_attention = computed.flash_attention,
+        "auto-tuned parameters"
+    );
+
+    // Populate model metrics with system info and computed parameters
+    {
+        let mut metrics_guard = metrics.lock().unwrap();
+
+        // System info
+        metrics_guard.cpu_threads = Some(system_info.cpu_threads);
+        metrics_guard.gpu_devices = Some(
+            system_info
+                .devices
+                .iter()
+                .map(|d| GpuDeviceInfo {
+                    name: d.name.clone(),
+                    backend: d.backend.clone(),
+                    device_type: format!("{:?}", d.device_type),
+                    memory_total_mb: Some(d.memory_total_bytes / (1024 * 1024)),
+                    memory_free_mb: Some(d.memory_free_bytes / (1024 * 1024)),
+                })
+                .collect(),
+        );
+
+        // Computed parameters
+        metrics_guard.n_ctx = Some(computed.n_ctx);
+        metrics_guard.n_batch = Some(computed.n_batch);
+        metrics_guard.n_ubatch = Some(computed.n_ubatch);
+        metrics_guard.n_gpu_layers = Some(computed.n_gpu_layers);
+        metrics_guard.n_threads = Some(computed.n_threads);
+        metrics_guard.flash_attention = Some(computed.flash_attention);
+
+        // Model info from GGUF metadata
+        metrics_guard.model_params_billions = Some(model_params_count);
+        metrics_guard.model_layers = Some(model_layers);
+        metrics_guard.quantization = file_type;
+        metrics_guard.model_n_ctx_train = Some(model_n_ctx_train);
+    }
+
+    // Apply computed parameters to model (recreate with computed n_gpu_layers if different)
+    // Note: We keep the model loaded, just use computed for context
+    let context_params = LlamaContextParams::default()
+        .with_n_ctx(NonZeroU32::new(computed.n_ctx))
+        .with_n_batch(computed.n_batch)
+        .with_n_ubatch(computed.n_ubatch)
+        .with_n_threads(computed.n_threads)
+        .with_flash_attention_policy(flash_attention_policy(computed.flash_attention));
 
     // Get model's built-in template from gguf metadata
     let model_template = model
@@ -326,9 +436,13 @@ fn run_event_loop(
         n_batch: n_batch_ctx,
         previous_tokens: Vec::new(),
         position: 0,
-        checkpoint_manager: CheckpointManager::new(max_checkpoints, is_hybrid, n_ctx as usize),
+        checkpoint_manager: CheckpointManager::new(
+            max_checkpoints,
+            is_hybrid,
+            computed.n_ctx as usize,
+        ),
         is_hybrid,
-        n_ctx: n_ctx as i32,
+        n_ctx: computed.n_ctx as i32,
     };
 
     while let Some(request) = request_rx.blocking_recv() {
@@ -360,11 +474,77 @@ fn determine_transition_type(messages: &[ChatMessage]) -> TransitionType {
     TransitionType::TurnStart
 }
 
+/// Decode with memory error recovery.
+/// This function attempts to decode the batch, and if it fails due to memory issues,
+/// it will try to recover by trimming the KV cache.
+///
+/// Returns:
+/// - Ok(()) on successful decode
+/// - Err(MemoryTrimmedError) if decode failed and memory was trimmed (caller should trim session)
+/// - Err(anyhow::Error) for other decode errors
+fn decode_with_recovery(
+    context: &mut LlamaContext,
+    batch: &mut LlamaBatch,
+    state: &mut RequestState,
+) -> Result<(), MemoryTrimmedError> {
+    // First attempt
+    match context.decode(batch) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            tracing::warn!("decode failed (first attempt): {}", e);
+
+            // Store position before recovery
+            let _position_before = state.position;
+
+            // Try to recover
+            let recovered = handle_memory_error(
+                context,
+                state.is_hybrid,
+                state.n_ctx,
+                Some(&mut state.checkpoint_manager),
+                &mut state.position,
+                &mut state.previous_tokens,
+            );
+            if !recovered {
+                return Err(MemoryTrimmedError);
+            }
+
+            batch.clear();
+
+            // Re-add last token to batch after recovery
+            // This is critical - without this, decode fails with "n_tokens == 0"
+            if let Some(&last_token) = state.previous_tokens.last() {
+                let pos = state.position; // position was reset by handle_memory_error
+                if let Err(e) = batch.add(last_token, pos, &[0], true) {
+                    tracing::error!("failed to re-add token to batch after recovery: {}", e);
+                    return Err(MemoryTrimmedError);
+                }
+                tracing::debug!("re-added token to batch for retry, position={}", pos);
+            } else {
+                tracing::debug!("no previous tokens after recovery, proceeding with empty batch");
+            }
+
+            // Second attempt after recovery
+            match context.decode(batch) {
+                Ok(()) => {
+                    tracing::info!("decode succeeded after OOM recovery");
+                    // Return MemoryTrimmedError so caller knows to trim session history too
+                    Err(MemoryTrimmedError)
+                }
+                Err(e) => {
+                    tracing::error!("decode failed even after recovery: {}", e);
+                    Err(MemoryTrimmedError)
+                }
+            }
+        }
+    }
+}
+
 #[tracing::instrument(skip_all)]
 fn handle_request(
     resources: ModelResources,
     state: &mut RequestState,
-    context: &mut llama_cpp_2::context::LlamaContext,
+    context: &mut LlamaContext,
     request: Request,
 ) {
     let Request {
@@ -657,8 +837,38 @@ fn handle_request(
                 }
                 in_token_count += 1;
             }
-            if let Err(e) = context.decode(&mut batch) {
-                let _ = response_tx.blocking_send(Err(anyhow!("decode failed: {}", e)));
+            // Use decode with memory recovery
+            if let Err(_e) = decode_with_recovery(context, &mut batch, state) {
+                // Memory was trimmed - send completion with trim signal instead of error
+                // This allows generation to continue gracefully
+                let _ = response_tx.blocking_send(Ok(Completion::Response(CompletionResponse {
+                    text: String::new(),
+                    thought: None,
+                    tool_calls: None,
+                    finish_reason: Some("trimmed".to_string()), // Signal that session needs trimming
+                    raw_chunk: None,
+                })));
+                // Note: We don't have prompt_eval_latency_ms or generated_tokens here yet,
+                // send minimal metrics to indicate the event
+                let _ = response_tx.blocking_send(Ok(Completion::Metrics(CompletionMetrics {
+                    prompt_tokens: tokens.len() as u32,
+                    prompt_eval_latency_ms: 0.0,
+                    completion_tokens: 0,
+                    completion_latency_ms: 0.0,
+                    thought: None,
+                    raw_chunk: None,
+                    cache_metrics: Some(CacheMetrics {
+                        cache_hit: cache_status.cache_hit,
+                        strategy: Some(if state.is_hybrid {
+                            "Hybrid".to_string()
+                        } else {
+                            "KvCacheOnly".to_string()
+                        }),
+                        tokens_skipped: None,
+                        n_ctx: Some(state.n_ctx),
+                        checkpoint_transition: None,
+                    }),
+                })));
                 return;
             }
 
@@ -741,8 +951,37 @@ fn handle_request(
             let _ = response_tx.blocking_send(Err(anyhow!("batch add failed: {}", e)));
             return;
         }
-        if let Err(e) = context.decode(&mut batch) {
-            let _ = response_tx.blocking_send(Err(anyhow!("decode failed: {}", e)));
+        // Use decode with memory recovery
+        if let Err(_e) = decode_with_recovery(context, &mut batch, state) {
+            // Memory was trimmed - send completion with trim signal instead of error
+            // This allows generation to continue gracefully
+            let completion_latency_ms = generation_start.elapsed().as_millis() as f32;
+            let _ = response_tx.blocking_send(Ok(Completion::Response(CompletionResponse {
+                text: String::new(),
+                thought: None,
+                tool_calls: None,
+                finish_reason: Some("trimmed".to_string()), // Signal that session needs trimming
+                raw_chunk: None,
+            })));
+            let _ = response_tx.blocking_send(Ok(Completion::Metrics(CompletionMetrics {
+                prompt_tokens: tokens.len() as u32,
+                prompt_eval_latency_ms,
+                completion_tokens: generated_tokens,
+                completion_latency_ms,
+                thought: None,
+                raw_chunk: None,
+                cache_metrics: Some(CacheMetrics {
+                    cache_hit: cache_status.cache_hit,
+                    strategy: Some(if state.is_hybrid {
+                        "Hybrid".to_string()
+                    } else {
+                        "KvCacheOnly".to_string()
+                    }),
+                    tokens_skipped: None,
+                    n_ctx: Some(state.n_ctx),
+                    checkpoint_transition: None,
+                }),
+            })));
             return;
         }
 

--- a/crates/core/src/provider/gguf/system.rs
+++ b/crates/core/src/provider/gguf/system.rs
@@ -1,0 +1,566 @@
+//! System detection and parameter computation for llama.cpp.
+//! Uses GGML backend APIs to detect CPU/GPU hardware and compute optimal params.
+
+use llama_cpp_2::{LlamaBackendDeviceType, context::LlamaContext, list_llama_ggml_backend_devices};
+
+/// Bytes per gigabyte constant.
+const GB: f64 = 1024.0 * 1024.0 * 1024.0;
+
+/// Information about detected hardware devices.
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+    /// Device name (e.g. "Vulkan0", "CUDA0")
+    pub name: String,
+    /// Backend name (e.g. "Vulkan", "CUDA", "CPU")
+    pub backend: String,
+    /// Device type
+    pub device_type: LlamaBackendDeviceType,
+    /// Total memory in bytes
+    pub memory_total_bytes: usize,
+    /// Free/available memory in bytes
+    pub memory_free_bytes: usize,
+}
+
+/// System hardware information.
+#[derive(Debug, Clone)]
+pub struct SystemInfo {
+    /// Number of available CPU threads
+    pub cpu_threads: usize,
+    /// Detected devices (CPU, GPU, etc.)
+    pub devices: Vec<DeviceInfo>,
+}
+
+/// Computed optimal parameters for llama.cpp.
+#[derive(Debug, Clone)]
+pub struct ComputeParams {
+    /// Context window size
+    pub n_ctx: u32,
+    /// Logical batch size for prompt processing
+    pub n_batch: u32,
+    /// Physical batch size for prompt processing
+    pub n_ubatch: u32,
+    /// Number of GPU layers to offload (0 = CPU only, >0 = number of layers)
+    pub n_gpu_layers: i32,
+    /// Number of threads for inference
+    pub n_threads: i32,
+    /// Enable flash attention
+    pub flash_attention: bool,
+}
+
+impl Default for ComputeParams {
+    fn default() -> Self {
+        Self {
+            n_ctx: 4096,
+            n_batch: 512,
+            n_ubatch: 512,
+            n_gpu_layers: 0,
+            n_threads: 4,
+            flash_attention: true,
+        }
+    }
+}
+
+/// Config overrides from user configuration.
+#[derive(Debug, Default, Clone)]
+pub struct ConfigOverrides {
+    pub n_ctx: Option<u32>,
+    pub n_batch: Option<u32>,
+    pub n_gpu_layers: Option<i32>,
+    pub n_threads: Option<i32>,
+    pub flash_attention: Option<bool>,
+    pub n_ubatch: Option<u32>,
+}
+
+/// Quantization type detected from model file type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum Quantization {
+    /// Full precision (16-bit float)
+    F16,
+    /// 8-bit quantization
+    Q8_0,
+    /// 6-bit quantization with block structure
+    Q6_K,
+    /// 5-bit quantization with block structure
+    Q5_K,
+    /// 4-bit quantization with block structure (medium)
+    Q4_K,
+    /// 4-bit quantization simple
+    Q4_0,
+    /// Unknown quantization type
+    Unknown,
+}
+
+impl Quantization {
+    /// Parse quantization type from file type string.
+    /// File type examples: "Q4_K_M", "Q8_0", "F16", "Q6_K", "Q5_K_S"
+    pub fn from_file_type(file_type: &str) -> Self {
+        let file_type_upper = file_type.to_uppercase();
+        if file_type_upper.contains("F16") {
+            Quantization::F16
+        } else if file_type_upper.contains("Q8_0") {
+            Quantization::Q8_0
+        } else if file_type_upper.contains("Q6_K") {
+            Quantization::Q6_K
+        } else if file_type_upper.contains("Q5_K") {
+            Quantization::Q5_K
+        } else if file_type_upper.contains("Q4_K") {
+            Quantization::Q4_K
+        } else if file_type_upper.contains("Q4_0") {
+            Quantization::Q4_0
+        } else {
+            Quantization::Unknown
+        }
+    }
+
+    /// Returns estimated memory per 1 billion parameters per layer in GB.
+    /// These values are approximate and vary based on model architecture.
+    pub fn memory_per_layer_base_gb(&self) -> f64 {
+        match self {
+            Quantization::F16 => 2.0,
+            Quantization::Q8_0 => 1.0,
+            Quantization::Q6_K => 0.7,
+            Quantization::Q5_K => 0.5,
+            Quantization::Q4_K => 0.35,
+            Quantization::Q4_0 => 0.5,
+            Quantization::Unknown => 0.5, // Conservative estimate
+        }
+    }
+}
+
+/// Error returned when memory was trimmed during decode (for session recovery).
+/// This signals the caller to also trim message history.
+#[derive(Debug)]
+pub struct MemoryTrimmedError;
+
+impl std::fmt::Display for MemoryTrimmedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "memory was trimmed, session history needs trimming")
+    }
+}
+
+impl std::error::Error for MemoryTrimmedError {}
+
+/// Detect system hardware using GGML backend APIs.
+pub fn detect_system_info() -> SystemInfo {
+    let devices: Vec<DeviceInfo> = list_llama_ggml_backend_devices()
+        .into_iter()
+        .map(|d| DeviceInfo {
+            name: d.name,
+            backend: d.backend,
+            device_type: d.device_type,
+            memory_total_bytes: d.memory_total,
+            memory_free_bytes: d.memory_free,
+        })
+        .collect();
+
+    let cpu_threads = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(4);
+
+    tracing::debug!(
+        cpu_threads = cpu_threads,
+        devices = devices.len(),
+        "detected system info"
+    );
+
+    for device in &devices {
+        tracing::debug!(
+            name = %device.name,
+            backend = %device.backend,
+            device_type = ?device.device_type,
+            memory_total_mb = device.memory_total_bytes / (1024 * 1024),
+            memory_free_mb = device.memory_free_bytes / (1024 * 1024),
+            "detected device"
+        );
+    }
+
+    SystemInfo {
+        cpu_threads,
+        devices,
+    }
+}
+
+/// Find the first GPU device (not CPU).
+fn find_primary_gpu(devices: &[DeviceInfo]) -> Option<&DeviceInfo> {
+    devices.iter().find(|d| {
+        matches!(
+            d.device_type,
+            LlamaBackendDeviceType::Gpu | LlamaBackendDeviceType::IntegratedGpu
+        )
+    })
+}
+
+/// Check if GPU offload is recommended based on available VRAM.
+fn should_enable_gpu(system: &SystemInfo) -> bool {
+    if let Some(gpu) = find_primary_gpu(&system.devices) {
+        // Enable GPU if we have at least 2GB free VRAM
+        let free_gb = gpu.memory_free_bytes as f64 / GB;
+        tracing::debug!(free_vram_gb = free_gb, "GPU VRAM check");
+        return free_gb >= 2.0;
+    }
+    false
+}
+
+/// Compute the number of GPU layers to offload based on available VRAM and model size.
+/// Uses quantization-aware memory estimation.
+///
+/// # Arguments
+/// * `system` - System info with GPU device details
+/// * `model_layers` - Number of layers in the model
+/// * `params_billions` - Model size in billions of parameters (e.g., 4.21 for 4.21B)
+/// * `quantization` - Quantization type of the model
+///
+/// # Returns
+/// Number of layers to offload to GPU (0 for CPU-only)
+pub fn compute_n_gpu_layers(
+    system: &SystemInfo,
+    model_layers: u32,
+    params_billions: f64,
+    quantization: Quantization,
+) -> i32 {
+    let Some(gpu) = find_primary_gpu(&system.devices) else {
+        tracing::debug!("no GPU found, using CPU only");
+        return 0;
+    };
+
+    let free_vram_gb = gpu.memory_free_bytes as f64 / GB;
+
+    // Reserve 15% of VRAM for KV cache and scratch space
+    let usable_vram_gb = free_vram_gb * 0.85;
+
+    // Calculate memory per layer based on model size and quantization
+    let mem_per_layer_gb = quantization.memory_per_layer_base_gb() * params_billions;
+
+    // Calculate how many layers can fit in available VRAM
+    let layers_fit = (usable_vram_gb / mem_per_layer_gb).floor() as u32;
+
+    // Cap at model layer count
+    let n_gpu_layers = layers_fit.min(model_layers) as i32;
+
+    tracing::info!(
+        free_vram_gb = free_vram_gb,
+        usable_vram_gb = usable_vram_gb,
+        mem_per_layer_gb = mem_per_layer_gb,
+        model_layers = model_layers,
+        layers_fit = layers_fit,
+        n_gpu_layers = n_gpu_layers,
+        quantization = ?quantization,
+        "computed GPU layers"
+    );
+
+    n_gpu_layers
+}
+
+/// Compute optimal parameters based on system and model info.
+pub fn compute_params(
+    system: &SystemInfo,
+    model_n_ctx_train: u32,
+    model_layers: u32,
+    params_billions: f64,
+    quantization: Quantization,
+    overrides: &ConfigOverrides,
+) -> ComputeParams {
+    // Determine if GPU should be used
+    let use_gpu = should_enable_gpu(system);
+
+    // n_gpu_layers: compute based on VRAM and model size
+    let computed_n_gpu_layers = if use_gpu {
+        compute_n_gpu_layers(system, model_layers, params_billions, quantization)
+    } else {
+        0
+    };
+
+    // n_threads: reduce if using GPU to leave headroom
+    let base_threads = system.cpu_threads as i32;
+    let n_threads = if use_gpu {
+        // Use half threads when GPU is active for better balance
+        (base_threads / 2).max(1)
+    } else {
+        base_threads
+    };
+
+    // n_ctx: use model's trained context, capped at reasonable max
+    let n_ctx = model_n_ctx_train.max(512);
+
+    // n_batch: scale with context size, cap at 2048
+    let n_batch = (n_ctx / 2).clamp(32, 2048);
+
+    // n_ubatch: should be divisor of n_batch, cap at 512
+    let n_ubatch = (n_batch / 4).clamp(32, 512);
+
+    // flash_attention: enabled by default (auto-detected by llama.cpp)
+    let flash_attention = true;
+
+    // Apply overrides from config
+    let computed = ComputeParams {
+        n_ctx: overrides.n_ctx.unwrap_or(n_ctx),
+        n_batch: overrides.n_batch.unwrap_or(n_batch),
+        n_ubatch: overrides.n_ubatch.unwrap_or(n_ubatch),
+        n_gpu_layers: overrides.n_gpu_layers.unwrap_or(computed_n_gpu_layers),
+        n_threads: overrides.n_threads.unwrap_or(n_threads),
+        flash_attention: overrides.flash_attention.unwrap_or(flash_attention),
+    };
+
+    tracing::debug!(
+        n_ctx = computed.n_ctx,
+        n_batch = computed.n_batch,
+        n_ubatch = computed.n_ubatch,
+        n_gpu_layers = computed.n_gpu_layers,
+        n_threads = computed.n_threads,
+        flash_attention = computed.flash_attention,
+        use_gpu = use_gpu,
+        "computed params"
+    );
+
+    computed
+}
+
+/// Get the llama flash attention policy value.
+/// -1 = AUTO, 0 = DISABLED, 1 = ENABLED
+pub fn flash_attention_policy(enabled: bool) -> i32 {
+    if enabled {
+        -1 // LLAMA_FLASH_ATTN_TYPE_AUTO
+    } else {
+        0 // LLAMA_FLASH_ATTN_TYPE_DISABLED
+    }
+}
+
+/// Handle memory error by trimming KV cache.
+/// Returns true if trim was successful, false otherwise.
+///
+/// # Arguments
+/// * `context` - Llama context with KV cache
+/// * `is_hybrid` - Whether the model is hybrid/recurrent
+/// * `n_ctx` - Context window size
+/// * `checkpoint_manager` - Checkpoint manager for hybrid models
+/// * `position` - Current position in context
+/// * `previous_tokens` - Previous tokens vector to clear
+pub fn handle_memory_error(
+    context: &mut LlamaContext,
+    is_hybrid: bool,
+    n_ctx: i32,
+    checkpoint_manager: Option<&mut crate::provider::gguf::checkpoint::CheckpointManager>,
+    position: &mut i32,
+    previous_tokens: &mut Vec<llama_cpp_2::token::LlamaToken>,
+) -> bool {
+    if is_hybrid {
+        // Hybrid models: Full clear required as kv_cache_seq_keep doesn't work
+        tracing::warn!("hybrid model OOM, clearing all state");
+
+        // Clear all checkpoints
+        if let Some(cm) = checkpoint_manager {
+            cm.clear();
+        }
+
+        // Reset position and clear tokens
+        *position = 0;
+        previous_tokens.clear();
+
+        // Clear KV cache
+        context.clear_kv_cache();
+
+        tracing::info!("hybrid state cleared for OOM recovery");
+    } else {
+        // Non-hybrid: Trim to 50% of context
+        let n_keep = ((n_ctx as usize) / 2).max(512);
+
+        // Trim KV cache - keep only the most recent tokens
+        // Note: llama_kv_cache_seq_keep keeps only up to seq_id, we use 0 for all sequences
+        context.llama_kv_cache_seq_keep(n_keep as i32);
+
+        tracing::info!("trimmed KV cache to {} tokens for OOM recovery", n_keep);
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quantization_from_file_type_q4_k() {
+        assert_eq!(Quantization::from_file_type("Q4_K_M"), Quantization::Q4_K);
+        assert_eq!(Quantization::from_file_type("Q4_K_S"), Quantization::Q4_K);
+        assert_eq!(Quantization::from_file_type("q4_k_m"), Quantization::Q4_K);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_q8() {
+        assert_eq!(Quantization::from_file_type("Q8_0"), Quantization::Q8_0);
+        assert_eq!(Quantization::from_file_type("q8_0"), Quantization::Q8_0);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_q6() {
+        assert_eq!(Quantization::from_file_type("Q6_K"), Quantization::Q6_K);
+        assert_eq!(Quantization::from_file_type("q6_k"), Quantization::Q6_K);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_q5() {
+        assert_eq!(Quantization::from_file_type("Q5_K_S"), Quantization::Q5_K);
+        assert_eq!(Quantization::from_file_type("Q5_K_M"), Quantization::Q5_K);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_q4_0() {
+        assert_eq!(Quantization::from_file_type("Q4_0"), Quantization::Q4_0);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_f16() {
+        assert_eq!(Quantization::from_file_type("F16"), Quantization::F16);
+        assert_eq!(Quantization::from_file_type("f16"), Quantization::F16);
+    }
+
+    #[test]
+    fn test_quantization_from_file_type_unknown() {
+        assert_eq!(
+            Quantization::from_file_type("unknown"),
+            Quantization::Unknown
+        );
+        assert_eq!(Quantization::from_file_type(""), Quantization::Unknown);
+        assert_eq!(Quantization::from_file_type("Q3"), Quantization::Unknown);
+    }
+
+    #[test]
+    fn test_memory_per_layer_f16() {
+        let mem = Quantization::F16.memory_per_layer_base_gb();
+        assert!((mem - 2.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_q8_0() {
+        let mem = Quantization::Q8_0.memory_per_layer_base_gb();
+        assert!((mem - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_q6_k() {
+        let mem = Quantization::Q6_K.memory_per_layer_base_gb();
+        assert!((mem - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_q5_k() {
+        let mem = Quantization::Q5_K.memory_per_layer_base_gb();
+        assert!((mem - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_q4_k() {
+        let mem = Quantization::Q4_K.memory_per_layer_base_gb();
+        assert!((mem - 0.35).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_q4_0() {
+        let mem = Quantization::Q4_0.memory_per_layer_base_gb();
+        assert!((mem - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_per_layer_unknown() {
+        let mem = Quantization::Unknown.memory_per_layer_base_gb();
+        assert!((mem - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_memory_trimmed_error_display() {
+        let err = MemoryTrimmedError;
+        let msg = err.to_string();
+        assert!(msg.contains("memory"));
+        assert!(msg.contains("trimmed"));
+    }
+
+    #[test]
+    fn test_config_overrides_partial() {
+        let overrides = ConfigOverrides {
+            n_ctx: Some(8192),
+            n_batch: None,
+            n_gpu_layers: Some(16),
+            n_threads: None,
+            flash_attention: None,
+            n_ubatch: None,
+        };
+
+        assert_eq!(overrides.n_ctx, Some(8192));
+        assert_eq!(overrides.n_batch, None);
+        assert_eq!(overrides.n_gpu_layers, Some(16));
+    }
+
+    #[test]
+    fn test_compute_params_with_overrides() {
+        let system = SystemInfo {
+            cpu_threads: 8,
+            devices: vec![],
+        };
+        let overrides = ConfigOverrides {
+            n_ctx: Some(8192),
+            n_batch: Some(1024),
+            n_gpu_layers: Some(16),
+            n_threads: Some(4),
+            flash_attention: Some(false),
+            n_ubatch: Some(256),
+        };
+
+        let params = compute_params(
+            &system,
+            4096, // model_n_ctx_train
+            32,   // model_layers
+            7.0,  // params_billions
+            Quantization::Q4_K,
+            &overrides,
+        );
+
+        assert_eq!(params.n_ctx, 8192);
+        assert_eq!(params.n_batch, 1024);
+        assert_eq!(params.n_gpu_layers, 16);
+        assert_eq!(params.n_threads, 4);
+        assert!(!params.flash_attention);
+        assert_eq!(params.n_ubatch, 256);
+    }
+
+    #[test]
+    fn test_compute_params_defaults() {
+        let system = SystemInfo {
+            cpu_threads: 8,
+            devices: vec![],
+        };
+        let overrides = ConfigOverrides::default();
+
+        let params = compute_params(
+            &system,
+            4096, // model_n_ctx_train
+            32,   // model_layers
+            7.0,  // params_billions
+            Quantization::Q4_K,
+            &overrides,
+        );
+
+        // Should use computed defaults (CPU only since no GPU)
+        assert_eq!(params.n_ctx, 4096);
+        assert_eq!(params.n_batch, 2048);
+        assert_eq!(params.n_gpu_layers, 0); // No GPU in system
+        assert_eq!(params.n_threads, 8);
+        assert!(params.flash_attention);
+    }
+
+    #[test]
+    fn test_detect_system_info() {
+        let info = detect_system_info();
+
+        // Should have at least CPU
+        assert!(info.cpu_threads > 0);
+        assert!(!info.devices.is_empty());
+
+        // CPU should be present
+        let cpu_device = info
+            .devices
+            .iter()
+            .find(|d| d.device_type == LlamaBackendDeviceType::Cpu);
+        assert!(cpu_device.is_some());
+    }
+}

--- a/crates/core/src/provider/gguf/tool.rs
+++ b/crates/core/src/provider/gguf/tool.rs
@@ -94,6 +94,7 @@ impl ToolCallParser {
     }
 
     pub fn reset(&self) {
+        debug!("ToolCallParser: resetting parser state");
         let mut buffer = self.buffer.lock().unwrap();
         buffer.clear();
         let mut state = self.is_in_thought.lock().unwrap();
@@ -173,6 +174,7 @@ impl ToolCallParser {
                     match match_type {
                         0 => {
                             // Thought start
+                            debug!("ToolCallParser: thought start");
                             let m = thought_start.unwrap();
                             *is_in_thought = true;
                             current_pos += m.end();
@@ -182,6 +184,8 @@ impl ToolCallParser {
                             let m = tool_call_match.unwrap();
                             let abs_end = current_pos + (m.end() - m.start());
                             let content = &buffer[current_pos..abs_end];
+
+                            debug!("ToolCallParser: complete tool call");
 
                             // Extract the inner content (captured by group 1 in complete_call_re)
                             if let Some(caps) = self.complete_call_re.captures(content)

--- a/crates/core/src/provider/openai.rs
+++ b/crates/core/src/provider/openai.rs
@@ -74,6 +74,7 @@ impl OpenAIBaseModel {
             client,
             metrics: ModelMetrics {
                 init_latency_ms: 0.0,
+                ..Default::default()
             },
         })
     }
@@ -633,7 +634,12 @@ mod tests {
 
         let cancel_token = CancellationToken::new(); // Create a token for the test
         let mut stream = model
-            .complete(&messages, Some(&tools), &HashMap::new(), cancel_token)
+            .complete(
+                &messages,
+                Some(tools.as_slice()),
+                &HashMap::new(),
+                cancel_token,
+            )
             .await;
 
         // Collect and assert on responses

--- a/crates/core/src/provider/test_provider.rs
+++ b/crates/core/src/provider/test_provider.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// A mock `CompletionModel` for use in unit tests.
 ///
@@ -25,6 +26,7 @@ use std::sync::Arc;
 pub struct TestProviderModel {
     config: ModelConfig,
     metrics: ModelMetrics,
+    reset_called: Arc<AtomicBool>,
 }
 
 impl TestProviderModel {
@@ -33,7 +35,19 @@ impl TestProviderModel {
         Ok(Self {
             config,
             metrics: ModelMetrics::default(),
+            reset_called: Arc::new(AtomicBool::new(false)),
         })
+    }
+
+    /// Returns true if reset() has been called on this model.
+    pub fn was_reset(&self) -> bool {
+        self.reset_called.load(Ordering::SeqCst)
+    }
+
+    /// Resets the reset_called flag (for test isolation).
+    #[cfg(test)]
+    pub fn reset_flag(&self) {
+        self.reset_called.store(false, Ordering::SeqCst);
     }
 }
 
@@ -114,6 +128,7 @@ impl CompletionModel for TestProviderModel {
     }
 
     async fn reset(&self) -> Result<()> {
+        self.reset_called.store(true, Ordering::SeqCst);
         Ok(())
     }
 }

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -1,0 +1,234 @@
+use crate::tools::Tool;
+use std::sync::Arc;
+
+/// Global registry for all available tools in the application.
+///
+/// # Design Rationale
+///
+/// ToolRegistry serves as the single source of truth for all tools.
+/// It can hold different tool types:
+/// - **Direct tools**: Implemented in Rust, executed locally
+/// - **MCP tools** (future): Remote tools via MCP protocol
+///
+/// The Session doesn't need to know HOW a tool executes - it just calls
+/// `tool.execute()`. The Tool trait abstracts away local vs remote execution.
+///
+/// # Usage
+///
+/// ```rust
+/// use arey_core::registry::ToolRegistry;
+/// use arey_core::tools::Tool;
+/// use async_trait::async_trait;
+/// use serde_json::json;
+/// use std::sync::Arc;
+///
+/// // A dummy tool for example
+/// struct ExampleTool;
+/// #[async_trait]
+/// impl Tool for ExampleTool {
+///     fn name(&self) -> String { "example".to_string() }
+///     fn description(&self) -> String { "An example tool".to_string() }
+///     fn parameters(&self) -> serde_json::Value { json!({"type": "object"}) }
+///     async fn execute(&self, _args: &serde_json::Value) -> Result<serde_json::Value, arey_core::tools::ToolError> {
+///         Ok(json!({"result": "ok"}))
+///     }
+/// }
+///
+/// let mut registry = ToolRegistry::new();
+/// registry.register(Arc::new(ExampleTool))?;
+///
+/// // Get specific tools by name
+/// let tools = registry.tools_for(&["example".to_string()]);
+/// assert_eq!(tools.len(), 1);
+///
+/// // Or get all tool names
+/// let all_names = registry.list();
+/// assert_eq!(all_names, vec!["example"]);
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub struct ToolRegistry {
+    tools: std::collections::HashMap<String, Arc<dyn Tool>>,
+}
+
+impl ToolRegistry {
+    /// Create a new empty tool registry.
+    pub fn new() -> Self {
+        Self {
+            tools: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Register a tool in the registry.
+    ///
+    /// Returns error if a tool with the same name is already registered.
+    pub fn register(&mut self, tool: Arc<dyn Tool>) -> anyhow::Result<()> {
+        let name = tool.name();
+        if self.tools.contains_key(&name) {
+            anyhow::bail!("Tool '{}' already registered", name);
+        }
+        self.tools.insert(name, tool);
+        Ok(())
+    }
+
+    /// Get a tool by name.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+
+    /// List all registered tool names.
+    pub fn list(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
+    /// Get a subset of tools by their names.
+    ///
+    /// Returns tools for all names that exist in the registry.
+    /// Silently ignores names that don't exist.
+    pub fn tools_for(&self, names: &[String]) -> Vec<Arc<dyn Tool>> {
+        names
+            .iter()
+            .filter_map(|name| self.tools.get(name).cloned())
+            .collect()
+    }
+}
+
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::{Tool, ToolError};
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use serde_json::json;
+
+    #[derive(Clone)]
+    struct DummyTool;
+
+    #[async_trait]
+    impl Tool for DummyTool {
+        fn name(&self) -> String {
+            "dummy".to_string()
+        }
+
+        fn description(&self) -> String {
+            "A dummy tool".to_string()
+        }
+
+        fn parameters(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &Value) -> Result<Value, ToolError> {
+            Ok(json!({"status": "ok"}))
+        }
+    }
+
+    #[derive(Clone)]
+    struct OtherTool;
+
+    #[async_trait]
+    impl Tool for OtherTool {
+        fn name(&self) -> String {
+            "other".to_string()
+        }
+
+        fn description(&self) -> String {
+            "Another tool".to_string()
+        }
+
+        fn parameters(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &Value) -> Result<Value, ToolError> {
+            Ok(json!({"status": "ok"}))
+        }
+    }
+    #[test]
+    fn test_registry_new() {
+        let registry = ToolRegistry::new();
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn test_registry_register() {
+        let mut registry = ToolRegistry::new();
+        let tool: Arc<dyn Tool> = Arc::new(DummyTool);
+
+        let result = registry.register(tool);
+        assert!(result.is_ok());
+        assert_eq!(registry.list().len(), 1);
+    }
+
+    #[test]
+    fn test_registry_register_duplicate() {
+        let mut registry = ToolRegistry::new();
+        let tool: Arc<dyn Tool> = Arc::new(DummyTool);
+
+        registry.register(tool.clone()).unwrap();
+        let result = registry.register(tool);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_registry_get() {
+        let mut registry = ToolRegistry::new();
+        let tool: Arc<dyn Tool> = Arc::new(DummyTool);
+        registry.register(tool).unwrap();
+
+        let retrieved = registry.get("dummy");
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().name(), "dummy");
+    }
+
+    #[test]
+    fn test_registry_tools_for() {
+        let mut registry = ToolRegistry::new();
+        let tool1: Arc<dyn Tool> = Arc::new(DummyTool);
+        let tool2: Arc<dyn Tool> = Arc::new(OtherTool);
+        registry.register(tool1).unwrap();
+        registry.register(tool2).unwrap();
+
+        let tools = registry.tools_for(&["dummy".to_string()]);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "dummy");
+    }
+
+    #[test]
+    fn test_registry_tools_for_multiple() {
+        let mut registry = ToolRegistry::new();
+        let tool1: Arc<dyn Tool> = Arc::new(DummyTool);
+        let tool2: Arc<dyn Tool> = Arc::new(OtherTool);
+        registry.register(tool1).unwrap();
+        registry.register(tool2).unwrap();
+
+        let tools = registry.tools_for(&["dummy".to_string(), "other".to_string()]);
+        assert_eq!(tools.len(), 2);
+    }
+
+    #[test]
+    fn test_registry_tools_for_ignores_nonexistent() {
+        let mut registry = ToolRegistry::new();
+        let tool: Arc<dyn Tool> = Arc::new(DummyTool);
+        registry.register(tool).unwrap();
+
+        let tools = registry.tools_for(&["dummy".to_string(), "nonexistent".to_string()]);
+        assert_eq!(tools.len(), 1);
+    }
+
+    #[test]
+    fn test_registry_get_nonexistent() {
+        let mut registry = ToolRegistry::new();
+        let tool: Arc<dyn Tool> = Arc::new(DummyTool);
+        registry.register(tool).unwrap();
+
+        let result = registry.get("nonexistent");
+        assert!(result.is_none());
+    }
+}

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -3,557 +3,429 @@
 
 use crate::{
     completion::{CancellationToken, ChatMessage, Completion, CompletionModel, SenderType},
+    context::Context as SessionContext,
     get_completion_llm,
-    model::{ModelConfig, ModelMetrics, ModelProvider},
-    provider::test_provider::TestProviderModel,
-    tools::{Tool, ToolCall, ToolResult},
+    model::{ModelConfig, ModelMetrics},
+    tools::{Tool, ToolCall, ToolExecutor},
 };
 use anyhow::{Context, Result};
-use futures::stream::BoxStream;
+use futures::stream::{BoxStream, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::{debug, error};
+use tracing::{debug, error, info, warn};
 
-/// Safety margin reserved for template overhead and edge cases
-/// This is 10% of context size, minimum 64 tokens
-fn safety_margin(context_size: usize) -> usize {
-    if context_size <= 640 {
-        // For small contexts, use smaller margin
-        context_size / 20
-    } else {
-        // For larger contexts, use 10% up to 512 max
-        (context_size / 10).min(512)
+/// Immutable configuration snapshot for a session.
+///
+/// All fields are public for direct initialization. Use `SessionConfig::default()`
+/// for defaults, or create directly:
+///
+/// ```
+/// use std::sync::Arc;
+/// use arey_core::tools::Tool;
+/// use arey_core::session::SessionConfig;
+/// use std::collections::HashMap;
+///
+/// // Example with tools
+/// // let my_tool: Arc<dyn Tool> = ...;
+/// let config = SessionConfig {
+///     system_prompt: "You are helpful".to_string(),
+///     tools: vec![/* my_tool */],
+///     settings: HashMap::new(),
+///     enable_reasoning: Some(true),
+///     max_tool_iterations: 10,
+///     tool_execution_enabled: true,
+/// };
+/// ```
+#[derive(Clone)]
+pub struct SessionConfig {
+    pub system_prompt: String,
+    pub tools: Vec<Arc<dyn Tool>>,
+    pub settings: HashMap<String, String>,
+    pub enable_reasoning: Option<bool>,
+    pub max_tool_iterations: usize,
+    pub tool_execution_enabled: bool,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            system_prompt: String::new(),
+            tools: Vec::new(),
+            settings: HashMap::new(),
+            enable_reasoning: None,
+            max_tool_iterations: 10,
+            tool_execution_enabled: true,
+        }
     }
+}
+
+impl SessionConfig {
+    /// Create a new SessionConfig with the given tools (convenience constructor)
+    pub fn with_tools(tools: Vec<Arc<dyn Tool>>) -> Self {
+        Self {
+            tools,
+            ..Default::default()
+        }
+    }
+}
+
+/// Events emitted during session generation
+pub enum SessionEvent {
+    /// Token response from model
+    Token(Completion),
+    /// Compaction (summarization) started
+    CompactionStart,
+    /// Compaction (summarization) completed
+    CompactionEnd {
+        result: crate::context::CompactionResult,
+    },
+    /// Reasoning (thinking) started
+    ReasoningStart,
+    /// Reasoning (thinking) completed
+    ReasoningEnd { reasoning: Option<String> },
+    /// Tool execution started
+    ToolStart { calls: Vec<ToolCall> },
+    /// Tool execution completed: Vec of (tool_call, succeeded) pairs
+    ToolEnd { results: Vec<(ToolCall, bool)> },
 }
 
 /// A session with shared context between Human and AI model.
 pub struct Session {
     model: Box<dyn CompletionModel>,
     model_key: String,
-    context_size: usize,
-    system_prompt: String,
-    messages: Vec<(ChatMessage, Option<usize>)>,
-    tools: Vec<Arc<dyn Tool>>,
-    settings: HashMap<String, String>,
-    metrics: Option<ModelMetrics>,
-    /// Template override: enable_thinking setting
-    /// None = use model's default, Some(true) = enable thinking, Some(false) = disable thinking
-    enable_thinking: Option<bool>,
+    context: SessionContext,
+    config: SessionConfig,
+    metrics: ModelMetrics,
+    model_reset_called: bool,
 }
 
 impl Session {
-    /// Create a new session with the given model configuration
-    pub fn new(model_config: ModelConfig, system_prompt: &str) -> Result<Self> {
+    /// Create a new session with the given model configuration and session config.
+    pub fn new(model_config: ModelConfig, config: SessionConfig) -> Result<Self> {
         let model_key = model_config.key.clone();
         let model = get_completion_llm(model_config.clone())
             .context("Failed to initialize session model")?;
 
-        let context_size = model_config.get_setting::<usize>("n_ctx").unwrap_or(4096);
-        let metrics = Some(model.metrics());
+        let context_size = model_config
+            .get_setting::<usize>("n_ctx")
+            .or_else(|| model.metrics().n_ctx.map(|n| n as usize))
+            .unwrap_or(4096);
+        let metrics = model.metrics();
+
+        debug!(
+            "Session created with context_size={} (from config: {}, from model: {:?})",
+            context_size,
+            model_config.get_setting::<usize>("n_ctx").unwrap_or(4096),
+            metrics.n_ctx
+        );
 
         Ok(Self {
             model,
             model_key,
-            context_size,
-            system_prompt: system_prompt.to_string(),
-            messages: Vec::new(),
-            tools: Vec::new(),
-            settings: HashMap::new(),
+            context: SessionContext::new(context_size).with_system(config.system_prompt.clone()),
+            config,
             metrics,
-            enable_thinking: None,
+            model_reset_called: false,
         })
     }
 
-    /// Set a new system prompt for the session.
-    pub fn set_system_prompt(&mut self, prompt: &str) -> Result<()> {
-        self.system_prompt = prompt.to_string();
-        Ok(())
+    /// Update the session configuration atomically.
+    pub fn update_config(&mut self, config: SessionConfig) {
+        self.config = config;
     }
 
-    /// Get the enable_thinking setting.
-    pub fn enable_thinking(&self) -> Option<bool> {
-        self.enable_thinking
-    }
-
-    /// Set the enable_thinking template parameter.
-    /// None = use model's default, Some(true) = enable thinking, Some(false) = disable thinking
-    pub fn set_enable_thinking(&mut self, enabled: Option<bool>) {
-        self.enable_thinking = enabled;
-    }
-
-    /// Get model key for retrieving details from config
-    pub fn model_key(&self) -> String {
-        self.model_key.clone()
-    }
-
-    /// Get system prompt
-    pub fn system_prompt(&self) -> String {
-        self.system_prompt.clone()
-    }
-
-    /// Transfer existing message history to session
-    pub fn set_messages(&mut self, messages: Vec<ChatMessage>) -> Result<()> {
-        self.messages = messages
-            .into_iter()
-            .map(|msg| (msg, None)) // Reset token counts for new model
-            .collect();
-        Ok(())
-    }
-
-    /// Add a new message to the conversation history
-    pub fn add_message(&mut self, message: ChatMessage) -> Result<()> {
-        if message.sender != SenderType::Assistant {
-            self.messages.push((message, None));
-            return Ok(());
-        }
-
-        // Add assistant message. Assume assistant message is fully received.
-        // Back-fill token counts for messages sent in the last prompt and adds the
-        // assistant's response with its token count.
-        let messages = &mut self.messages;
-
-        let mut known_prompt_tokens: usize = 0;
-        let mut unknown_message_indices = Vec::new();
-        let mut total_unknown_chars = 0;
-
-        // Identify messages that were part of the prompt and don't have a token count yet.
-        for (i, (msg, count)) in messages.iter().enumerate() {
-            if let Some(count) = *count {
-                known_prompt_tokens += count;
-            } else {
-                unknown_message_indices.push(i);
-                // Use character length as a heuristic for distribution.
-                total_unknown_chars += msg.text.len();
-            }
-        }
-
-        // Calculate new tokens added by the assistant's response.
-        let metrics = message.clone().metrics.unwrap();
-        let new_tokens = (metrics.prompt_tokens as usize).saturating_sub(known_prompt_tokens);
-
-        if !unknown_message_indices.is_empty() {
-            if total_unknown_chars > 0 {
-                let mut distributed_tokens: usize = 0;
-                let last_index = unknown_message_indices.len() - 1;
-
-                // Distribute tokens proportionally, giving remainder to the last message.
-                for (i, msg_idx) in unknown_message_indices.iter().enumerate() {
-                    let msg_chars = messages[*msg_idx].0.text.len();
-                    let msg_tokens = if i == last_index {
-                        new_tokens.saturating_sub(distributed_tokens)
-                    } else {
-                        (new_tokens * msg_chars) / total_unknown_chars
-                    };
-                    messages[*msg_idx].1 = Some(msg_tokens);
-                    distributed_tokens += msg_tokens;
-                }
-            } else if unknown_message_indices.len() == 1 {
-                // Handle case where there's one message with no text.
-                messages[unknown_message_indices[0]].1 = Some(new_tokens);
-            }
-        }
-
-        messages.push((message, Some(metrics.completion_tokens as usize)));
-        Ok(())
-    }
-
-    /// Set the tools available for this session
-    pub fn set_tools(&mut self, tools: Vec<Arc<dyn Tool>>) -> Result<()> {
-        self.tools = tools;
-        Ok(())
-    }
-
-    /// Returns a clone of the tools available in the session.
-    pub fn tools(&self) -> Vec<Arc<dyn Tool>> {
-        self.tools.clone()
-    }
-
-    /// Replace the current model with a new one, ensuring proper cleanup
-    pub fn set_model(&mut self, model_config: ModelConfig) -> Result<()> {
+    /// Replace the current model with a new one, preserving conversation history
+    pub fn update_model(&mut self, model_config: ModelConfig) -> Result<()> {
         let model_key = model_config.key.clone();
         let context_size = model_config.get_setting::<usize>("n_ctx").unwrap_or(4096);
+        let old_messages = self.context.messages_tuple().to_vec();
 
-        // Create a temporary placeholder model to replace the old one
-        let temp_model = Box::new(TestProviderModel::new(ModelConfig {
-            key: "temp".to_string(),
-            name: "temp".to_string(),
-            provider: ModelProvider::Test,
-            settings: HashMap::new(),
-        })?) as Box<dyn CompletionModel>;
+        let temp_model = Box::new(crate::provider::test_provider::TestProviderModel::new(
+            ModelConfig {
+                key: "temp".to_string(),
+                name: "temp".to_string(),
+                provider: crate::model::ModelProvider::Test,
+                settings: HashMap::new(),
+            },
+        )?) as Box<dyn CompletionModel>;
 
-        // Replace and drop the old model to free GPU memory
         let old_model = std::mem::replace(&mut self.model, temp_model);
         drop(old_model);
 
-        // Now create the new model with the old model's memory freed
         self.model = get_completion_llm(model_config)?;
         self.model_key = model_key;
-        self.context_size = context_size;
+        self.context = SessionContext::new(context_size)
+            .with_system(self.config.system_prompt.clone())
+            .with_messages(old_messages);
 
         Ok(())
     }
 
-    /// Update agent configuration (prompt and tools) atomically
-    pub fn update_agent(&mut self, prompt: String, tools: Vec<Arc<dyn Tool>>) -> Result<()> {
-        self.system_prompt = prompt;
-        self.tools = tools;
+    /// Clear all messages from the session and reset model state
+    pub async fn clear(&mut self) -> Result<()> {
+        self.context.clear();
+        self.model.reset().await?;
+        self.model_reset_called = true;
         Ok(())
     }
 
-    /// Update generation settings
-    pub fn update_settings(&mut self, new_settings: HashMap<String, String>) -> Result<()> {
-        self.settings = new_settings;
-        Ok(())
+    /// Returns true if the model was reset during the last clear() call.
+    pub fn was_model_reset(&self) -> bool {
+        self.model_reset_called
     }
 
-    /// Generate a response stream for the current conversation
-    pub async fn generate(
-        &self,
-        mut settings: HashMap<String, String>,
-        cancel_token: CancellationToken,
-    ) -> Result<BoxStream<'static, Result<Completion>>> {
-        let tool_slice = if self.tools.is_empty() {
-            None
-        } else {
-            Some(self.tools.as_slice())
-        };
+    // ── Message access ─────────────────────────────────────────
 
-        let max_tokens = settings
-            .get("max_tokens")
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(1024);
-
-        tracing::debug!("Settings in session.generate(): max_tokens={}", max_tokens);
-
-        // Add enable_thinking to settings if set
-        if let Some(enabled) = self.enable_thinking {
-            settings.insert("enable_thinking".to_string(), enabled.to_string());
-        }
-
-        let messages_to_send =
-            self.get_trimmed_messages(&self.messages, max_tokens, &self.system_prompt);
-
-        Ok(self
-            .model
-            .complete(&messages_to_send, tool_slice, &settings, cancel_token)
-            .await)
+    /// Add a new message to the conversation history
+    pub fn add_message(&mut self, message: ChatMessage) -> Result<()> {
+        self.context.add_message(message)
     }
 
-    /// Clear the conversation history and reset the model state
-    pub async fn clear_history(&mut self) -> Result<()> {
-        self.messages.clear();
-        self.model.reset().await
-    }
-
-    /// Get model metrics if available
-    pub fn metrics(&self) -> Option<&ModelMetrics> {
-        self.metrics.as_ref()
-    }
-
-    /// Get all messages in the conversation
-    pub fn all_messages(&self) -> Vec<ChatMessage> {
-        self.messages.iter().map(|(msg, _)| msg.clone()).collect()
-    }
-
-    /// Get the last message from the assistant
-    pub fn last_assistant_message(&self) -> Option<ChatMessage> {
-        self.messages
+    /// Get all messages in conversation. Caller can derive count, last, etc. from this.
+    pub fn messages(&self) -> Vec<ChatMessage> {
+        self.context
+            .messages_tuple()
             .iter()
-            .rev()
-            .find(|(m, _)| m.sender == SenderType::Assistant)
-            .map(|(m, _)| m.clone())
+            .map(|(msg, _)| msg.clone())
+            .collect()
     }
 
-    /// Trims a single, oversized block of messages to fit within the available token budget.
+    /// Get current model key
+    pub fn model_key(&self) -> &str {
+        &self.model_key
+    }
+
+    // ── Tool execution ─────────────────────────────────────────
+
+    /// Get tools available in session
+    pub fn tools(&self) -> &[Arc<dyn Tool>] {
+        &self.config.tools
+    }
+
+    /// Get a tool by name from the session's tools
+    pub fn get_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.config.tools.iter().find(|t| t.name() == name).cloned()
+    }
+
+    /// Get current session configuration (read-only)
+    pub fn config(&self) -> &SessionConfig {
+        &self.config
+    }
+
+    /// Trim message history after model memory trim (OOM recovery).
+    /// This keeps only the most recent 50% of messages to match the KV cache trim.
+    /// Should be called when the model signals memory was trimmed.
+    pub fn trim_for_memory_recovery(&mut self) {
+        let _ = self.context.trim(true);
+    }
+
+    /// Generate a response stream for the current conversation.
     ///
-    /// This function works backwards from the end of the block, prioritizing newer messages.
-    /// It aggressively truncates `Tool` messages if necessary to make the block fit, ensuring
-    /// the returned list of messages strictly adheres to the token limit.
-    fn trim_oversized_block(
-        &self,
-        block_messages: &[(ChatMessage, Option<usize>)],
-        available_tokens: usize,
-        estimate_tokens_fn: &dyn Fn(&ChatMessage) -> usize,
-    ) -> Vec<ChatMessage> {
-        let mut final_messages = Vec::new();
-        let mut used_tokens = 0;
+    /// This method handles the full generate→execute_tool→generate loop when
+    /// tool_execution_enabled is true:
+    /// 1. Generate tokens from model
+    /// 2. If tool_calls detected and tool_execution_enabled:
+    ///    - emit ToolStart, execute tools in parallel, emit ToolEnd
+    ///    - add tool results to conversation
+    ///    - repeat until no tool calls or max_iterations reached
+    pub async fn generate(
+        &mut self,
+        settings: HashMap<String, String>,
+        cancel_token: CancellationToken,
+    ) -> Result<BoxStream<'_, Result<SessionEvent>>> {
+        Ok(async_stream::stream! {
+            let max_iterations = self.config.max_tool_iterations;
+            let tools_enabled = self.config.tool_execution_enabled && !self.config.tools.is_empty();
 
-        // Iterate forwards through the block to preserve conversational order.
-        for (msg, count) in block_messages.iter() {
-            let mut msg_to_add = msg.clone();
-            let mut tokens = count.unwrap_or_else(|| estimate_tokens_fn(&msg_to_add));
+            let mut iteration = 0;
+            let mut pending_tool_calls: Vec<ToolCall> = Vec::new();
 
-            if used_tokens + tokens > available_tokens {
-                // If the message doesn't fit, check if we can truncate it.
-                // We only truncate tool messages as they are the most likely to be verbose.
-                if msg_to_add.sender == SenderType::Tool {
-                    let budget_for_this_msg = available_tokens.saturating_sub(used_tokens);
-                    // Use a 4 chars/token heuristic to determine how much text to keep.
-                    let chars_to_keep = budget_for_this_msg * 4;
-                    if msg_to_add.text.len() > chars_to_keep {
-                        msg_to_add.text.truncate(chars_to_keep);
-                        msg_to_add.text.push_str("\n... [truncated]");
-                        // After truncation, the token cost is now the budget we had.
-                        tokens = budget_for_this_msg;
-                    } else {
-                        // It's a tool message but can't be truncated enough. Stop.
-                        break;
-                    }
+            loop {
+                // Check compaction
+                let needs_compaction = {
+                    let ctx = self.context.messages_tuple();
+                    self.context.needs_compaction(ctx)
+                };
+
+                if needs_compaction {
+                    yield Ok(SessionEvent::CompactionStart);
+                    let result = self.context.compact();
+                    yield Ok(SessionEvent::CompactionEnd { result });
+                }
+
+                // Trim context to fit budget before generation
+                if let Err(e) = self.context.trim(false) {
+                    error!("Failed to trim context: {}", e);
+                    yield Err(e);
+                    return;
+                }
+
+                // Get messages from working copy (already trimmed)
+                let mut messages_to_send: Vec<ChatMessage> = self
+                    .context
+                    .messages_tuple()
+                    .iter()
+                    .map(|(m, _)| m.clone())
+                    .collect();
+
+                // Prepend system prompt if set
+                if !self.config.system_prompt.is_empty() {
+                    messages_to_send.insert(
+                        0,
+                        ChatMessage {
+                            sender: SenderType::System,
+                            text: self.config.system_prompt.clone(),
+                            ..Default::default()
+                        },
+                    );
+                }
+
+                if messages_to_send.is_empty() {
+                    error!(
+                        "Cannot generate: zero messages to send. System prompt: '{}', Conversation messages: {}",
+                        self.config.system_prompt,
+                        self.context.messages_tuple().len()
+                    );
+                    return;
+                }
+
+                let mut effective_settings = settings.clone();
+                for (k, v) in &self.config.settings {
+                    effective_settings.entry(k.clone()).or_insert(v.clone());
+                }
+
+                if let Some(enabled) = self.config.enable_reasoning {
+                    effective_settings.insert("enable_thinking".to_string(), enabled.to_string());
+                }
+
+                let tool_slice = if self.config.tool_execution_enabled && !self.config.tools.is_empty() {
+                    self.config.tools.clone()
                 } else {
-                    // It's not a tool message and it doesn't fit. Stop.
+                    Vec::new()
+                };
+
+                let mut stream = self.model.complete(
+                    &messages_to_send,
+                    if tool_slice.is_empty() { None } else { Some(&tool_slice) },
+                    &effective_settings,
+                    cancel_token.clone()
+                ).await;
+
+                pending_tool_calls.clear();
+                let mut assistant_text = String::new();
+                let mut assistant_thought = String::new();
+                let mut final_metrics = None;
+
+                while let Some(item) = stream.next().await {
+                    match item {
+                        Ok(Completion::Response(resp)) => {
+                            if let Some(tool_calls) = &resp.tool_calls {
+                                pending_tool_calls.extend(tool_calls.clone());
+                            }
+                            if !resp.text.is_empty() {
+                                assistant_text.push_str(&resp.text);
+                            }
+                            if let Some(thought) = &resp.thought {
+                                assistant_thought.push_str(thought);
+                            }
+                            yield Ok(SessionEvent::Token(Completion::Response(resp)));
+                        }
+                        Ok(Completion::Metrics(m)) => {
+                            final_metrics = Some(m.clone());
+                            yield Ok(SessionEvent::Token(Completion::Metrics(m)));
+                        }
+                        Err(e) => {
+                            yield Err(e);
+                            return;
+                        }
+                    }
+                }
+
+                // Add assistant response to context before potentially looping for tools
+                let assistant_msg = ChatMessage {
+                    sender: SenderType::Assistant,
+                    text: assistant_text,
+                    thought: if assistant_thought.is_empty() {
+                        None
+                    } else {
+                        Some(assistant_thought)
+                    },
+                    tools: if pending_tool_calls.is_empty() {
+                        None
+                    } else {
+                        Some(pending_tool_calls.clone())
+                    },
+                    metrics: final_metrics,
+                };
+                let _ = self.add_message(assistant_msg);
+
+                // No more tool calls - exit loop
+                if pending_tool_calls.is_empty() {
+                    break;
+                }
+
+                // Execute tools
+                if !tools_enabled {
+                    info!("Tool calls detected but tool execution is disabled");
+                    break;
+                }
+
+                yield Ok(SessionEvent::ToolStart {
+                    calls: pending_tool_calls.clone(),
+                });
+
+                let mut tool_results: Vec<(ToolCall, bool)> = Vec::new();
+                for tool_call in &pending_tool_calls {
+                    let success = if let Some(tool) = self.get_tool(&tool_call.name) {
+                        match ToolExecutor::execute(tool_call, tool.as_ref()).await {
+                            Ok(result_msg) => {
+                                let _ = self.add_message(result_msg);
+                                true
+                            }
+                            Err(e) => {
+                                error!("Tool execution failed: {}", e);
+                                false
+                            }
+                        }
+                    } else {
+                        let error_msg = ChatMessage {
+                            sender: SenderType::Tool,
+                            text: format!("Unknown tool: {}", tool_call.name),
+                            ..Default::default()
+                        };
+                        let _ = self.add_message(error_msg);
+                        false
+                    };
+                    tool_results.push((tool_call.clone(), success));
+                }
+
+                yield Ok(SessionEvent::ToolEnd {
+                    results: tool_results,
+                });
+
+                iteration += 1;
+                if iteration >= max_iterations {
+                    warn!("Max tool iterations ({}) reached", max_iterations);
                     break;
                 }
             }
-
-            // Add the message only if it fits (either originally or after truncation).
-            if used_tokens + tokens <= available_tokens {
-                used_tokens += tokens;
-                final_messages.push(msg_to_add);
-            } else {
-                // This can happen if budget was 0 and truncation wasn't possible. Stop.
-                break;
-            }
-        }
-
-        debug!(
-            "Trimmed block of {} messages to {} messages using {} tokens",
-            block_messages.len(),
-            final_messages.len(),
-            used_tokens
-        );
-
-        final_messages
+        }.boxed())
     }
 
-    /// Returns a list of messages that fits within the model's context window.
-    /// It trims older messages, attempting to keep conversational turns intact.
-    fn get_trimmed_messages(
-        &self,
-        messages: &[(ChatMessage, Option<usize>)],
-        max_output_tokens: usize,
-        system_prompt: &str,
-    ) -> Vec<ChatMessage> {
-        // Leave room for the response plus safety margin for template overhead
-        let max_tokens = self
-            .context_size
-            .saturating_sub(max_output_tokens)
-            .saturating_sub(safety_margin(self.context_size));
-
-        // Heuristic for messages without a known token count.
-        let estimate_tokens = |msg: &ChatMessage| -> usize {
-            let mut tokens = msg.text.len() / 4;
-            if let Some(tools) = &msg.tools {
-                for tool_call in tools {
-                    tokens += tool_call.name.len() / 4;
-                    if let Ok(input_str) = serde_json::to_string(&tool_call.arguments) {
-                        tokens += input_str.len() / 4;
-                    }
-                }
-            }
-            tokens
-        };
-
-        let get_token_count = |(msg, count): &(ChatMessage, Option<usize>)| {
-            count.unwrap_or_else(|| estimate_tokens(msg))
-        };
-
-        let system_prompt_tokens = if system_prompt.is_empty() {
-            0
-        } else {
-            system_prompt.len() / 4
-        };
-        let available_tokens: usize = max_tokens.saturating_sub(system_prompt_tokens);
-        debug!(
-            "Token trimming: Context size: {}, Max output tokens: {}, Available tokens: {}, System prompt tokens: {}",
-            self.context_size, max_output_tokens, available_tokens, system_prompt_tokens
-        );
-
-        let mut start_index = messages.len();
-        let mut current_tokens = 0;
-        let mut current_block_tokens = 0;
-
-        // Iterate backwards to find the oldest message that fits in the context window.
-        for i in (0..messages.len()).rev() {
-            let msg = &messages[i];
-            current_block_tokens += get_token_count(msg);
-
-            // A "block" is a User message followed by non-User messages.
-            if msg.0.sender == SenderType::User || i == 0 {
-                if current_tokens + current_block_tokens <= available_tokens {
-                    current_tokens += current_block_tokens;
-                    start_index = i;
-                    current_block_tokens = 0;
-                } else {
-                    // This block is too big to fit with the others.
-                    if start_index == messages.len() {
-                        // This is the *most recent* block, and it's oversized.
-                        // We cannot simply discard it, as that would mean sending an empty prompt.
-                        // Instead, we must truncate it to fit the context window.
-                        debug!(
-                            "Token trimming: Most recent block is oversized ({} tokens > {} available). Truncating it.",
-                            current_block_tokens, available_tokens
-                        );
-                        let oversized_block = &messages[i..];
-
-                        // TODO: trimming this block and the tool msg trimming needs to be merged.
-                        return self.trim_oversized_block(
-                            oversized_block,
-                            available_tokens,
-                            &estimate_tokens,
-                        );
-                    } else {
-                        // This is an older block that doesn't fit. We stop here and
-                        // only include the newer blocks that have already been approved.
-                        // TODO: we should consider truncating the oversized block instead of discarding it.
-                        break;
-                    }
-                }
-            }
-        }
-
-        let mut final_messages: Vec<ChatMessage> = messages[start_index..]
-            .iter()
-            .map(|(m, _)| m.clone())
-            .collect();
-
-        // Skip token trimming if the entire message history fits within the context window.
-        if current_tokens + current_block_tokens <= available_tokens {
-            debug!(
-                "Token trimming: Trimming messages to fit within the context window. New start index: {}",
-                start_index
-            );
-
-            // Truncate all but the last tool message to a reasonable limit.
-            let last_tool_idx = final_messages
-                .iter()
-                .rposition(|m| m.sender == SenderType::Tool);
-
-            if let Some(last_idx) = last_tool_idx {
-                const MAX_TOOL_RESPONSE_CHARS: usize = 512;
-                const TRUNCATION_MARKER: &str = "... [truncated]";
-
-                for (i, msg) in final_messages.iter_mut().enumerate() {
-                    if i < last_idx
-                        && msg.sender == SenderType::Tool
-                        && msg.text.len() > MAX_TOOL_RESPONSE_CHARS
-                    {
-                        // Deserialize or handle errors gracefully
-                        let mut tool_output = match serde_json::from_str::<ToolResult>(
-                            msg.text.as_str(),
-                        ) {
-                            Ok(t) => t,
-                            Err(e) => {
-                                error!(
-                                    "Token trimming: Failed to deserialize ToolResult from message text: {}. Error: {}",
-                                    msg.text, e
-                                );
-                                ToolResult {
-                                    call: ToolCall {
-                                        id: "invalid".to_string(),
-                                        name: "invalid".to_string(),
-                                        arguments: "{}".to_string(),
-                                    },
-                                    output: serde_json::Value::String(msg.text.clone()),
-                                }
-                            }
-                        };
-
-                        // Serialize output field only
-                        let mut content = match serde_json::to_string(&tool_output.output) {
-                            Ok(c) => c,
-                            Err(e) => {
-                                error!(
-                                    "Token trimming: Failed to serialize tool output: {:?}. Error: {}",
-                                    tool_output.output, e
-                                );
-                                "[Tool output not serializable]".to_string()
-                            }
-                        };
-                        if content.len() > MAX_TOOL_RESPONSE_CHARS {
-                            let mut new_len = MAX_TOOL_RESPONSE_CHARS;
-
-                            // Ensure we don't cut off in the middle of a UTF-8 character.
-                            while !content.is_char_boundary(new_len) {
-                                new_len -= 1;
-                            }
-                            content.truncate(new_len);
-                            content.push_str(TRUNCATION_MARKER);
-                        }
-
-                        // Update output field and serialize full ToolResult
-                        tool_output.output = serde_json::Value::String(content);
-                        msg.text = match serde_json::to_string(&tool_output) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                error!(
-                                    "Token trimming: Failed to serialize ToolResult: {:?}. Error: {}",
-                                    tool_output, e
-                                );
-                                "[Tool output not available]".to_string()
-                            }
-                        };
-                    }
-                }
-            }
-        }
-
-        // Add system prompt at beginning of the messages
-        if !system_prompt.is_empty() {
-            final_messages.insert(
-                0,
-                ChatMessage {
-                    sender: SenderType::System,
-                    text: system_prompt.to_string(),
-                    ..Default::default()
-                },
-            );
-        }
-        final_messages
+    /// Get model metrics
+    pub fn metrics(&self) -> &ModelMetrics {
+        &self.metrics
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        completion::{Completion, CompletionMetrics},
-        model::ModelProvider,
-        tools::{ToolCall, ToolResult},
-    };
+    use crate::completion::{CompletionResponse, SenderType};
+    use crate::model::{ModelMetrics, ModelProvider};
     use async_trait::async_trait;
-    use serde_json::Value;
-    use std::collections::HashMap;
-
-    // A mock CompletionModel for testing purposes.
-    struct MockModel {}
-
-    impl MockModel {
-        fn new() -> Self {
-            Self {}
-        }
-    }
-
-    #[async_trait]
-    impl CompletionModel for MockModel {
-        fn metrics(&self) -> ModelMetrics {
-            ModelMetrics {
-                init_latency_ms: 0.0,
-            }
-        }
-        async fn complete(
-            &self,
-            _messages: &[ChatMessage],
-            _tools: Option<&[Arc<dyn Tool>]>,
-            _settings: &HashMap<String, String>,
-            _cancel_token: CancellationToken,
-        ) -> BoxStream<'static, Result<Completion>> {
-            let stream = futures::stream::iter(Vec::<Result<Completion>>::new());
-            Box::pin(stream)
-        }
-        async fn reset(&self) -> Result<()> {
-            Ok(())
-        }
-    }
+    use futures::stream::{self, BoxStream};
+    use std::sync::Arc;
 
     fn new_chat_msg(sender: SenderType, text: &str) -> ChatMessage {
         ChatMessage {
@@ -563,621 +435,459 @@ mod tests {
         }
     }
 
-    fn new_assistant_msg(
-        text: &str,
-        metrics: CompletionMetrics,
-        tools: Vec<ToolCall>,
-    ) -> ChatMessage {
-        ChatMessage {
-            sender: SenderType::Assistant,
-            text: text.to_string(),
-            tools: Some(tools),
-            metrics: Some(metrics),
-            ..Default::default()
-        }
-    }
-
-    fn new_session(context_size: usize) -> Session {
-        Session {
-            model: Box::new(MockModel::new()),
-            model_key: "test-model".to_string(),
-            context_size,
-            system_prompt: "System".to_string(), // 6 chars -> 1 token est.
-            messages: Vec::new(),
-            tools: Vec::new(),
+    fn new_session(_context_size: usize) -> Session {
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
             settings: HashMap::new(),
-            metrics: Some(ModelMetrics {
-                init_latency_ms: 0.0,
-            }),
-            enable_thinking: None,
-        }
+        };
+        Session::new(model_config, SessionConfig::default()).unwrap()
     }
 
-    fn new_tool_call(name: &str) -> ToolCall {
-        ToolCall {
-            id: "{name}_id".to_string(),
-            name: name.to_string(),
-            arguments: "{}".to_string(),
-        }
+    #[test]
+    fn test_session_new() {
+        let config = SessionConfig {
+            system_prompt: "Test".to_string(),
+            ..Default::default()
+        };
+
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
+            settings: HashMap::new(),
+        };
+
+        let session = Session::new(model_config, config).unwrap();
+        assert_eq!(session.model_key(), "test");
     }
 
     #[test]
     fn test_add_message() {
         let mut session = new_session(100);
+        session
+            .add_message(new_chat_msg(SenderType::User, "Hello"))
+            .unwrap();
+        assert_eq!(session.messages().len(), 1);
+    }
 
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Hello"));
+    #[test]
+    fn test_trim_for_memory_recovery() {
+        let mut session = new_session(100);
 
-        assert_eq!(session.messages.len(), 1);
-        assert_eq!(session.messages[0].0.text, "Hello");
-        assert_eq!(session.messages[0].1, None);
+        // Add 10 messages
+        for i in 0..10 {
+            session
+                .add_message(new_chat_msg(SenderType::User, &format!("Msg {}", i)))
+                .unwrap();
+        }
+        assert_eq!(session.messages().len(), 10);
+
+        session.trim_for_memory_recovery();
+
+        // Should keep last 50% = 5 messages
+        assert_eq!(session.messages().len(), 5);
+        assert_eq!(session.messages()[0].text, "Msg 5");
+    }
+
+    #[derive(Clone)]
+    #[allow(dead_code)]
+    struct MockModel {
+        response: Option<String>,
+        should_error: bool,
+    }
+
+    #[async_trait]
+    impl CompletionModel for MockModel {
+        fn metrics(&self) -> ModelMetrics {
+            ModelMetrics {
+                init_latency_ms: 0.0,
+                ..Default::default()
+            }
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ChatMessage],
+            _tools: Option<&[Arc<dyn Tool>]>,
+            _settings: &HashMap<String, String>,
+            _cancel_token: CancellationToken,
+        ) -> BoxStream<'static, Result<Completion>> {
+            if self.should_error {
+                return stream::iter([Err(anyhow::anyhow!("Mock error"))]).boxed();
+            }
+
+            let response = self.response.clone().unwrap_or_else(|| "Hello".to_string());
+            stream::iter([Ok(Completion::Response(CompletionResponse {
+                text: response,
+                tool_calls: None,
+                ..Default::default()
+            }))])
+            .boxed()
+        }
+
+        async fn reset(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tool_tests {
+    use super::*;
+    use crate::completion::{CompletionResponse, SenderType};
+    use crate::model::{ModelMetrics, ModelProvider};
+    use crate::tools::{Tool, ToolError};
+    use async_trait::async_trait;
+    use futures::TryStreamExt;
+    use futures::stream::{self, BoxStream, StreamExt};
+    use serde_json::{Value as JsonValue, json};
+    use serde_yaml::Value;
+    use std::sync::Arc;
+
+    fn new_chat_msg(sender: SenderType, text: &str) -> ChatMessage {
+        ChatMessage {
+            sender,
+            text: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestTool {
+        name: String,
+        should_error: bool,
+    }
+
+    #[async_trait]
+    impl Tool for TestTool {
+        fn name(&self) -> String {
+            self.name.clone()
+        }
+
+        fn description(&self) -> String {
+            format!("Test tool {}", self.name)
+        }
+
+        fn parameters(&self) -> JsonValue {
+            json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &JsonValue) -> Result<JsonValue, ToolError> {
+            if self.should_error {
+                Err(ToolError::ExecutionError(format!(
+                    "Tool {} failed",
+                    self.name
+                )))
+            } else {
+                Ok(json!({"result": format!("executed {}", self.name)}))
+            }
+        }
     }
 
     #[tokio::test]
-    async fn test_add_message_assistant_simple() {
-        let mut session = new_session(100);
-        let _ = session.add_message(new_chat_msg(SenderType::User, "User 1"));
+    async fn test_tool_start_event_emitted() -> Result<()> {
+        let tool: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "mock_tool".to_string(),
+            should_error: false,
+        });
 
-        let metrics = CompletionMetrics {
-            prompt_tokens: 10,
-            completion_tokens: 20,
-            ..Default::default()
-        };
-        let _ = session.add_message(new_assistant_msg("Response 1", metrics, Vec::new()));
-
-        assert_eq!(session.messages.len(), 2);
-        assert_eq!(session.messages[0].1, Some(10));
-        assert_eq!(session.messages[1].1, Some(20));
-    }
-
-    #[tokio::test]
-    async fn test_add_message_assistant_multiple_unknown() {
-        let mut session = new_session(100);
-        let _ = session.add_message(new_chat_msg(
-            SenderType::User,
-            "This is a slightly longer message.",
-        )); // 34 chars
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Short one.")); // 10 chars
-
-        let metrics = CompletionMetrics {
-            prompt_tokens: 100,
-            completion_tokens: 20,
-            ..Default::default()
-        };
-        let _ = session.add_message(new_assistant_msg("Response 1", metrics, Vec::new()));
-        assert_eq!(session.messages.len(), 3);
-        // 100 * (34 / (34+10)) = 77.27 -> 77
-        assert_eq!(session.messages[0].1, Some(77));
-        // Remainder: 100 - 77 = 23
-        assert_eq!(session.messages[1].1, Some(23));
-        assert_eq!(session.messages[2].1, Some(20));
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_no_trimming() {
-        let session = new_session(100);
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(10)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(10)),
-        ];
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-
-        assert_eq!(trimmed.len(), 3);
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_simple_trim() {
-        let session = new_session(30); // small context
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(10)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(10)),
-            (new_chat_msg(SenderType::User, "U2"), Some(10)),
-        ];
-        let system_prompt = session.system_prompt.clone();
-        // available_tokens = 30-1=29.
-        // U2 block (10) fits. current_tokens=10.
-        // U1 block (20) doesn't fit with U2 (10+20 > 29). Trim U1 block.
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-
-        assert_eq!(trimmed.len(), 2);
-        assert_eq!(trimmed[1].text, "U2");
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_keeps_blocks() {
-        let session = new_session(25); // Very small context to force trimming
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(10)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(10)),
-            (new_chat_msg(SenderType::User, "U2"), Some(10)),
-        ];
-        let system_prompt = session.system_prompt.clone();
-        // available_tokens = 25-1=24.
-        // U2 block (10) fits. U1+A1 block (20) doesn't fit with U2 (10+20 > 24).
-        // Should keep only U2 block (most recent).
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-
-        assert_eq!(trimmed.len(), 2);
-        assert_eq!(trimmed[1].text, "U2");
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_with_system_prompt() {
-        let session = new_session(30); // smaller context to force trimming
-        let system_prompt = "System prompt with much more text to consume tokens";
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(10)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(10)),
-            (new_chat_msg(SenderType::User, "U2"), Some(10)),
-        ];
-        // available_tokens = 30 - (system_prompt.len() / 4) = 30 - (48/4) = 30 - 12 = 18.
-        // U2 block (10) fits. U1+A1 block (20) doesn't fit with U2 (10+20 > 18).
-        // Should keep only U2 block.
-        let trimmed = session.get_trimmed_messages(&messages, 0, system_prompt);
-
-        assert_eq!(trimmed.len(), 2);
-        assert_eq!(trimmed[1].text, "U2");
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_exact_fit() {
-        let session = new_session(21); // exact fit for U2
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(20)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(20)),
-            (new_chat_msg(SenderType::User, "U2"), Some(10)),
-        ];
-        let system_prompt = session.system_prompt.clone();
-        // available_tokens = 21-1=20.
-        // U2 block (10) fits. current_tokens=10.
-        // U1 block (20) doesn't fit with U2 (10+20 > 20). Trim U1 block.
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-
-        assert_eq!(trimmed.len(), 2);
-        assert_eq!(trimmed[1].text, "U2");
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_empty_input() {
-        let session = new_session(30);
-        let messages = Vec::new();
-        let system_prompt = session.system_prompt.clone();
-
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-
-        // Only system prompt
-        assert_eq!(trimmed.len(), 1);
-    }
-
-    #[test]
-    fn test_get_trimmed_messages_all_fit() {
-        let session = new_session(100); // large context
-        let messages = vec![
-            (new_chat_msg(SenderType::User, "U1"), Some(10)),
-            (new_chat_msg(SenderType::Assistant, "A1"), Some(10)),
-            (new_chat_msg(SenderType::User, "U2"), Some(10)),
-        ];
-        let system_prompt = session.system_prompt.clone();
-        // available_tokens = 100-1=99.
-        // All messages fit easily.
-        let trimmed = session.get_trimmed_messages(&messages, 0, &system_prompt);
-        assert_eq!(trimmed.len(), 4);
-        assert_eq!(trimmed[1].text, "U1");
-        assert_eq!(trimmed[2].text, "A1");
-        assert_eq!(trimmed[3].text, "U2");
-    }
-
-    #[test]
-    fn test_full_flow() {
-        let mut session = new_session(35); // Reduced from 50 to force trimming
-
-        // Turn 1
-        let _ = session.add_message(new_chat_msg(
-            SenderType::User,
-            "User message 1, quite long to ensure it costs something",
-        ));
-        let metrics1 = CompletionMetrics {
-            prompt_tokens: 20,
-            completion_tokens: 10,
-            ..Default::default()
-        };
-        let _ = session.add_message(new_assistant_msg(
-            "Assistant response 1",
-            metrics1,
-            Vec::new(),
-        ));
-        assert_eq!(session.messages[0].1, Some(20));
-        assert_eq!(session.messages[1].1, Some(10));
-
-        // Turn 2
-        let _ = session.add_message(new_chat_msg(SenderType::User, "User message 2")); // est. 3 tokens
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-        // Sys(1)+U1_block(30)+U2_est(3) = 34 > 35. All still fit.
-        assert_eq!(trimmed.len(), 4);
-
-        let metrics2 = CompletionMetrics {
-            prompt_tokens: 35, // 20+10 known, so U2 cost is 5
-            completion_tokens: 5,
-            ..Default::default()
-        };
-        let _ = session.add_message(new_assistant_msg(
-            "Assistant response 2",
-            metrics2,
-            Vec::new(),
-        ));
-        assert_eq!(session.messages[2].1, Some(5));
-        assert_eq!(session.messages[3].1, Some(5));
-
-        // Turn 3: force trimming - with context of 35, system (1) + available = 34 tokens
-        // Messages: U1(20) + A1(10) + U2(5) + A2(5) + U3(est.7) = 47 tokens total
-        // Expected to trim U1+A1 block (30 tokens), keeping U2+A2+U3 (17 tokens)
-        let _ = session.add_message(new_chat_msg(
-            SenderType::User,
-            "User message 3 is also quite long",
-        )); // est. 7 tokens
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-
-        // Should have trimmed the oldest block (U1+A1) to fit within context
-        // Keeping: U2(5) + A2(5) + U3(est.7) = 17 tokens + system(1) = 18 tokens total
-        assert_eq!(trimmed.len(), 4); // Sys prompt, U2, A2, U3 - U1+A1 was trimmed
-        assert_eq!(trimmed[1].text, "User message 2"); // First message should be U2
-        assert_eq!(trimmed[2].text, "Assistant response 2"); // Second message should be A2
-        assert_eq!(trimmed[3].text, "User message 3 is also quite long"); // Third message should be U3
-    }
-
-    #[test]
-    fn test_trim_messages_with_tool_calls() {
-        let mut session = new_session(200); // Larger context to fit all messages
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Use the search tool"));
-        let _ = session.add_message(new_assistant_msg(
-            "I'll search for that information.",
-            CompletionMetrics::default(),
-            Vec::new(),
-        ));
-
-        // Simulate tool calls in the assistant message
-        session.messages[1].0.tools =
-            Some(vec![new_tool_call("search"), new_tool_call("calculate")]);
-
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, "Search result"));
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, "Calculation result"));
-
-        // Get trimmed messages with limited context
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-        // Should include all messages since they fit in context
-        assert_eq!(trimmed.len(), 5);
-    }
-
-    #[test]
-    fn test_trim_messages_oversized_tool_call() {
-        let mut session = new_session(50); // Very small context to force trimming
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Use the search tool"));
-        let _ = session.add_message(new_assistant_msg(
-            "I'll search for that information.",
-            CompletionMetrics::default(),
-            Vec::new(),
-        ));
-
-        // Simulate a large tool call that exceeds context
-        session.messages[1].0.tools = Some(vec![new_tool_call("search")]);
-
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, "Search result"));
-
-        // Add an extra message that should be trimmed
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Follow up question"));
-
-        // Get trimmed messages with limited context
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-        // Should trim the oldest user message to fit the tool call
-        assert!(trimmed.len() >= 3); // At least the assistant, tool, and latest user message
-    }
-
-    #[test]
-    fn test_trim_messages_with_invalid_tool_result() {
-        let mut session = new_session(100);
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Use the search tool"));
-        let _ = session.add_message(new_assistant_msg(
-            "I'll search for that information.",
-            CompletionMetrics::default(),
-            Vec::new(),
-        ));
-
-        // Simulate tool calls in the assistant message
-        session.messages[1].0.tools = Some(vec![new_tool_call("search")]);
-
-        // Add a tool result with invalid JSON (make it long enough to trigger truncation)
-        let invalid_json = format!(
-            r#"{{"call":{{"id":"search_id","name":"search","arguments":"{{}}"}},"output":""{}""#,
-            "invalid json ".repeat(100)
-        );
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, &invalid_json));
-
-        // Add another tool result (this will be the last one, forcing the first to be truncated)
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, "Second tool result"));
-
-        // Get trimmed messages
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-        // Should handle invalid JSON gracefully
-        assert_eq!(trimmed.len(), 4);
-
-        // Check if the invalid tool result was truncated
-        assert!(
-            trimmed[2].text.contains("... [truncated]"),
-            "Expected tool result to be truncated"
-        );
-    }
-
-    #[test]
-    fn test_record_completion_with_tools() {
-        let mut session = new_session(100);
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Use the search tool"));
-
-        let metrics = CompletionMetrics {
-            prompt_tokens: 10,
-            completion_tokens: 20,
-            ..Default::default()
-        };
-        let assistant_message = new_assistant_msg(
-            "I'll search for that information.",
-            metrics,
-            vec![new_tool_call("search")],
+        let mut settings: HashMap<String, Value> = HashMap::new();
+        settings.insert(
+            "response_mode".to_string(),
+            Value::String("tool_call".to_string()),
         );
 
-        let _ = session.add_message(assistant_message);
-
-        assert_eq!(session.messages.len(), 2);
-        assert_eq!(session.messages[1].1, Some(20));
-        assert_eq!(session.messages[1].0.tools.as_ref().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn test_trim_messages_extremely_large_tool_result() {
-        let mut session = new_session(300); // Very small context to force truncation
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Use the search tool"));
-
-        let assistant_message = new_assistant_msg(
-            "I'll search for that information.",
-            CompletionMetrics::default(),
-            vec![new_tool_call("search")],
-        );
-
-        let _ = session.add_message(assistant_message);
-
-        // Create a very large tool result
-        let large_tool_result =
-            r#"{"call":{"id":"search_id","name":"search","arguments":"{}"},"output":""#.to_string()
-                + &"x".repeat(1000)
-                + r#""#;
-        let tool_message = new_chat_msg(SenderType::Tool, &large_tool_result);
-        let _ = session.add_message(tool_message);
-
-        // Create another tool result (this will be the last one and won't be truncated)
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, "Small result"));
-
-        // Create another message
-        // let _ = session.add_message(new_chat_msg(SenderType::User, "Follow up"));
-
-        // Get trimmed messages
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-        // Check that it didn't panic and the tool message was truncated correctly.
-        // The tool result is very large (1070 chars) and should be truncated to 512 chars
-        assert!(
-            trimmed[3].text.contains("... [truncated]"),
-            "Expected tool result to be truncated. Text: {}...",
-            &trimmed[3].text[..100.min(trimmed[2].text.len())]
-        );
-        assert!(!trimmed[4].text.contains("... [truncated]")); // Follow-up message should not be truncated
-    }
-
-    #[test]
-    fn test_session_new() {
         let model_config = ModelConfig {
-            key: "test_key".to_string(),
-            name: "test_model".to_string(),
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
+            settings,
+        };
+
+        let session_config = SessionConfig {
+            tools: vec![tool],
+            ..Default::default()
+        };
+
+        let mut session = Session::new(model_config, session_config)?;
+        session.add_message(new_chat_msg(SenderType::User, "test"))?;
+
+        let stream = session
+            .generate(HashMap::new(), CancellationToken::new())
+            .await?;
+
+        let events: Vec<SessionEvent> = stream.try_collect().await?;
+
+        let tool_start_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, SessionEvent::ToolStart { .. }))
+            .collect();
+
+        assert!(
+            !tool_start_events.is_empty(),
+            "ToolStart event should be emitted"
+        );
+
+        if let SessionEvent::ToolStart { calls } = &tool_start_events[0] {
+            assert!(!calls.is_empty(), "ToolStart should have calls");
+            assert_eq!(calls[0].name, "mock_tool");
+        } else {
+            panic!("Expected ToolStart event");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tool_end_event_emitted_after_execution() -> Result<()> {
+        let tool: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "mock_tool".to_string(),
+            should_error: false,
+        });
+
+        let mut settings: HashMap<String, Value> = HashMap::new();
+        settings.insert(
+            "response_mode".to_string(),
+            Value::String("tool_call".to_string()),
+        );
+
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
+            settings,
+        };
+
+        let session_config = SessionConfig {
+            tools: vec![tool],
+            tool_execution_enabled: true,
+            ..Default::default()
+        };
+
+        let mut session = Session::new(model_config, session_config)?;
+        session.add_message(new_chat_msg(SenderType::User, "test"))?;
+
+        let stream = session
+            .generate(HashMap::new(), CancellationToken::new())
+            .await?;
+
+        let events: Vec<SessionEvent> = stream.try_collect().await?;
+
+        let tool_end_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, SessionEvent::ToolEnd { .. }))
+            .collect();
+
+        assert!(
+            !tool_end_events.is_empty(),
+            "ToolEnd event should be emitted"
+        );
+
+        if let SessionEvent::ToolEnd { results } = &tool_end_events[0] {
+            assert_eq!(results.len(), 1, "ToolEnd should have one result");
+            assert!(results[0].1, "Tool execution should succeed");
+        } else {
+            panic!("Expected ToolEnd event");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tool_result_message_added_to_context() -> Result<()> {
+        let tool: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "mock_tool".to_string(),
+            should_error: false,
+        });
+
+        let mut settings: HashMap<String, Value> = HashMap::new();
+        settings.insert(
+            "response_mode".to_string(),
+            Value::String("tool_call".to_string()),
+        );
+
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
+            settings,
+        };
+
+        let session_config = SessionConfig {
+            tools: vec![tool],
+            tool_execution_enabled: true,
+            ..Default::default()
+        };
+
+        let mut session = Session::new(model_config, session_config)?;
+        session.add_message(new_chat_msg(SenderType::User, "test"))?;
+
+        let stream = session
+            .generate(HashMap::new(), CancellationToken::new())
+            .await?;
+        let _ = stream.try_collect::<Vec<_>>().await?;
+
+        let messages = session.messages();
+
+        let tool_messages: Vec<_> = messages
+            .iter()
+            .filter(|m| m.sender == SenderType::Tool)
+            .collect();
+
+        assert!(
+            !tool_messages.is_empty(),
+            "Tool result message should be added to context"
+        );
+
+        let first_tool_msg = &tool_messages[0];
+        let parsed: serde_json::Value = serde_json::from_str(&first_tool_msg.text)?;
+        assert!(
+            parsed.get("output").is_some(),
+            "Tool result should contain output"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_tool_execution_error() -> Result<()> {
+        let tool: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "mock_tool".to_string(),
+            should_error: true,
+        });
+
+        let mut settings: HashMap<String, Value> = HashMap::new();
+        settings.insert(
+            "response_mode".to_string(),
+            Value::String("tool_call".to_string()),
+        );
+
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
+            provider: ModelProvider::Test,
+            settings,
+        };
+
+        let session_config = SessionConfig {
+            tools: vec![tool],
+            tool_execution_enabled: true,
+            ..Default::default()
+        };
+
+        let mut session = Session::new(model_config, session_config)?;
+        session.add_message(new_chat_msg(SenderType::User, "test"))?;
+
+        let stream = session
+            .generate(HashMap::new(), CancellationToken::new())
+            .await?;
+
+        let events: Vec<SessionEvent> = stream.try_collect().await?;
+
+        let tool_end_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, SessionEvent::ToolEnd { .. }))
+            .collect();
+
+        assert!(
+            !tool_end_events.is_empty(),
+            "ToolEnd should be emitted on error too"
+        );
+
+        if let SessionEvent::ToolEnd { results } = &tool_end_events[0] {
+            assert_eq!(results.len(), 1, "ToolEnd should have one result");
+            assert!(!results[0].1, "Tool execution should fail");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires architecture to inject custom model into Session"]
+    async fn test_tools_passed_to_model_complete() -> Result<()> {
+        struct ModelCapturesTools {
+            captured_tools: Arc<std::sync::Mutex<Option<Vec<String>>>>,
+        }
+
+        #[async_trait]
+        impl CompletionModel for ModelCapturesTools {
+            fn metrics(&self) -> ModelMetrics {
+                ModelMetrics::default()
+            }
+
+            async fn complete(
+                &self,
+                _messages: &[ChatMessage],
+                tools: Option<&[Arc<dyn Tool>]>,
+                _settings: &HashMap<String, String>,
+                _cancel_token: CancellationToken,
+            ) -> BoxStream<'static, Result<Completion>> {
+                let tool_names = tools.map(|t| t.iter().map(|t| t.name()).collect::<Vec<_>>());
+                *self.captured_tools.lock().unwrap() = tool_names;
+
+                stream::iter([Ok(Completion::Response(CompletionResponse {
+                    text: "Hello".to_string(),
+                    tool_calls: None,
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                }))])
+                .boxed()
+            }
+
+            async fn reset(&self) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let tool1: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "search".to_string(),
+            should_error: false,
+        });
+        let tool2: Arc<dyn Tool> = Arc::new(TestTool {
+            name: "weather".to_string(),
+            should_error: false,
+        });
+
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let captured_for_model = captured.clone();
+
+        let _model = ModelCapturesTools {
+            captured_tools: captured_for_model,
+        };
+
+        let model_config = ModelConfig {
+            key: "test".to_string(),
+            name: "Test".to_string(),
             provider: ModelProvider::Test,
             settings: HashMap::new(),
         };
-        let session = Session::new(model_config, "test_system_prompt").unwrap();
-        assert_eq!(session.model_key, "test_key");
-        assert_eq!(session.context_size, 4096); // default value
-        assert_eq!(session.system_prompt, "test_system_prompt");
-        assert!(session.messages.is_empty());
-        assert!(session.tools.is_empty());
-        assert!(session.settings.is_empty());
-    }
 
-    #[tokio::test]
-    async fn test_clear_history() {
-        let mut session = new_session(100);
-        let _ = session.add_message(new_chat_msg(SenderType::User, "Hello"));
-        let _ = session.add_message(new_assistant_msg(
-            "Hi there",
-            CompletionMetrics::default(),
-            Vec::new(),
-        ));
-        assert_eq!(session.messages.len(), 2);
+        let session_config = SessionConfig {
+            tools: vec![tool1, tool2],
+            tool_execution_enabled: true,
+            ..Default::default()
+        };
 
-        session.clear_history().await.unwrap();
-        assert_eq!(session.messages.len(), 0);
-    }
+        let mut session = Session::new(model_config, session_config)?;
+        session.add_message(new_chat_msg(SenderType::User, "hello"))?;
 
-    #[test]
-    fn test_settings() {
-        let mut session = new_session(100);
-        session
-            .settings
-            .insert("temperature".to_string(), "0.7".to_string());
-        session
-            .settings
-            .insert("top_p".to_string(), "0.9".to_string());
+        let stream = session
+            .generate(HashMap::new(), CancellationToken::new())
+            .await?;
+        let _ = stream.try_collect::<Vec<_>>().await?;
+
+        let captured_tools = captured.lock().unwrap();
+        let tools_passed = captured_tools.as_ref().expect("Tools should be captured");
 
         assert_eq!(
-            session.settings.get("temperature"),
-            Some(&"0.7".to_string())
+            tools_passed.len(),
+            2,
+            "Both tools should be passed to model"
         );
-        assert_eq!(session.settings.get("top_p"), Some(&"0.9".to_string()));
-    }
-
-    #[test]
-    fn test_tool_response_truncation_with_multibyte_chars() {
-        // This test ensures that truncating a tool response with multi-byte characters
-        // does not panic by cutting a character in half.
-        let mut session = new_session(4096);
-
-        // Construct a string where the truncation boundary (512) falls within a multi-byte character.
-        // `content` will be `"` + `long_string` + `"`.
-        // The euro sign '€' is 3 bytes and starts at byte index 511 of `content`.
-        let long_string = "a".to_string().repeat(510) + "€"; // 513 bytes as a string slice.
-
-        let tool_outputs = [
-            ToolResult {
-                call: new_tool_call("tool_1"),
-                output: Value::String(long_string),
-            },
-            ToolResult {
-                call: new_tool_call("tool_2"),
-                output: Value::String("b".to_string().repeat(10)), // A dummy second tool call
-            },
-        ];
-
-        let serialized_outputs: Vec<String> = tool_outputs
-            .iter()
-            .map(|out| serde_json::to_string(out).unwrap())
-            .collect();
-
-        let _ = session.add_message(new_chat_msg(SenderType::User, "U1"));
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, &serialized_outputs[0]));
-        let _ = session.add_message(new_chat_msg(SenderType::User, "U2"));
-        let _ = session.add_message(new_chat_msg(SenderType::Tool, &serialized_outputs[1]));
-
-        // Get trimmed messages using the same pattern as other tests
-        let messages_to_send: Vec<(ChatMessage, Option<usize>)> = session
-            .messages
-            .iter()
-            .map(|(msg, tokens)| (msg.clone(), *tokens))
-            .collect();
-        let system_prompt = session.system_prompt.clone();
-        let trimmed = session.get_trimmed_messages(&messages_to_send, 0, &system_prompt);
-
-        // Check that it didn't panic and the first message was truncated correctly.
-        assert!(trimmed[2].text.contains("... [truncated]"));
-        assert!(!trimmed[4].text.contains("... [truncated]"));
-    }
-
-    #[test]
-    fn test_set_model() -> Result<()> {
-        let mut session = new_session(100);
-        let original_model_key = session.model_key();
-        assert_eq!(original_model_key, "test-model");
-
-        // Create a new model config with different key
-        let new_model_config = ModelConfig {
-            key: "new-test-model".to_string(),
-            name: "new-test-model".to_string(),
-            provider: ModelProvider::Test,
-            settings: HashMap::new(),
-        };
-
-        // Set new model
-        session.set_model(new_model_config)?;
-
-        // Verify model was updated
-        assert_eq!(session.model_key(), "new-test-model");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_set_model_preserves_session_data() -> Result<()> {
-        let mut session = new_session(100);
-
-        // Add some data to the session
-        session.add_message(new_chat_msg(SenderType::User, "Hello"))?;
-        session.add_message(new_assistant_msg(
-            "Hi there",
-            CompletionMetrics::default(),
-            Vec::new(),
-        ))?;
-        let original_prompt = session.system_prompt();
-
-        // Create a new model config
-        let new_model_config = ModelConfig {
-            key: "new-test-model".to_string(),
-            name: "new-test-model".to_string(),
-            provider: ModelProvider::Test,
-            settings: HashMap::new(),
-        };
-
-        // Set new model
-        session.set_model(new_model_config)?;
-
-        // Verify session data is preserved
-        assert_eq!(session.model_key(), "new-test-model");
-        assert_eq!(session.system_prompt(), original_prompt);
-        assert_eq!(session.all_messages().len(), 2);
-        assert_eq!(session.all_messages()[0].text, "Hello");
-        assert_eq!(session.all_messages()[1].text, "Hi there");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_set_model_with_gguf_config() -> Result<()> {
-        let mut session = new_session(100);
-
-        // Create a GGUF model config (even if path doesn't exist, we test the flow)
-        let mut gguf_settings = HashMap::new();
-        gguf_settings.insert("path".to_string(), "/nonexistent/model.gguf".into());
-
-        let gguf_config = ModelConfig {
-            key: "gguf-test-model".to_string(),
-            name: "gguf-test-model".to_string(),
-            provider: ModelProvider::Gguf,
-            settings: gguf_settings,
-        };
-
-        let result = session.set_model(gguf_config);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("not found") || err_msg.contains("Model loading failed"));
-
-        assert_eq!(session.model_key(), "test-model");
+        assert!(tools_passed.contains(&"search".to_string()));
+        assert!(tools_passed.contains(&"weather".to_string()));
 
         Ok(())
     }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1,13 +1,122 @@
+use crate::completion::{ChatMessage, SenderType};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 use thiserror::Error;
+use tracing::debug;
 
 #[derive(Error, Debug)]
 pub enum ToolError {
     #[error("Tool execution failed: {0}")]
     ExecutionError(String),
+}
+
+pub struct ToolExecutor;
+
+impl ToolExecutor {
+    pub async fn execute(call: &ToolCall, tool: &dyn Tool) -> Result<ChatMessage, ToolError> {
+        let args = Self::normalize_arguments(&call.arguments)?;
+        debug!("Executing tool: {} with arguments: {}", call.name, args);
+        let mut output = tool
+            .execute(&args)
+            .await
+            .map_err(|e| ToolError::ExecutionError(e.to_string()))?;
+
+        // Clean control characters from tool output
+        Self::clean_value(&mut output);
+
+        Ok(Self::create_result_message(call, output))
+    }
+
+    /// Recursively removes control characters from JSON values
+    fn clean_value(value: &mut Value) {
+        match value {
+            Value::String(s) => {
+                let cleaned = s.replace(|c: char| c.is_control(), "");
+                *s = cleaned;
+            }
+            Value::Array(a) => a.iter_mut().for_each(Self::clean_value),
+            Value::Object(m) => m.values_mut().for_each(Self::clean_value),
+            _ => {}
+        }
+    }
+
+    pub fn normalize_arguments(arguments: &str) -> Result<Value, ToolError> {
+        let args = match serde_json::from_str::<Value>(arguments) {
+            Ok(value) => value,
+            Err(_first_error) => match serde_json::from_str::<Value>(arguments) {
+                Ok(value) => value,
+                Err(_) => {
+                    serde_json::json!({ "input": arguments })
+                }
+            },
+        };
+
+        let args = match &args {
+            Value::String(s) => match serde_json::from_str::<Value>(s) {
+                Ok(parsed_value) => parsed_value,
+                Err(_) => args,
+            },
+            _ => args,
+        };
+
+        Ok(args)
+    }
+
+    pub fn create_result_message(call: &ToolCall, output: Value) -> ChatMessage {
+        let call_id = if call.id.is_empty() {
+            format!("call_{}", rand_id())
+        } else {
+            call.id.clone()
+        };
+
+        let tool_result = ToolResult {
+            call: ToolCall {
+                id: call_id.clone(),
+                name: call.name.clone(),
+                arguments: call.arguments.clone(),
+            },
+            output,
+        };
+
+        ChatMessage {
+            sender: SenderType::Tool,
+            text: serde_json::to_string(&tool_result).unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+
+    pub fn create_error_message(call: &ToolCall, error: &ToolError) -> ChatMessage {
+        let call_id = if call.id.is_empty() {
+            format!("call_{}", rand_id())
+        } else {
+            call.id.clone()
+        };
+
+        let tool_result = ToolResult {
+            call: ToolCall {
+                id: call_id.clone(),
+                name: call.name.clone(),
+                arguments: call.arguments.clone(),
+            },
+            output: serde_json::json!({ "error": error.to_string() }),
+        };
+
+        ChatMessage {
+            sender: SenderType::Tool,
+            text: serde_json::to_string(&tool_result).unwrap_or_default(),
+            ..Default::default()
+        }
+    }
+}
+
+fn rand_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}_{}", duration.as_nanos(), std::process::id())
 }
 
 /// Represents a tool call requested by the model.
@@ -85,7 +194,7 @@ pub trait Tool: Send + Sync {
 }
 
 #[cfg(test)]
-mod tests {
+mod spec_tests {
     use super::*;
     use serde_json::json;
 
@@ -171,5 +280,238 @@ mod tests {
         });
 
         assert_eq!(serialized, expected);
+    }
+}
+
+#[cfg(test)]
+mod executor_tests {
+    use super::*;
+    use crate::completion::SenderType;
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    #[derive(Clone)]
+    struct TestTool;
+
+    #[async_trait]
+    impl Tool for TestTool {
+        fn name(&self) -> String {
+            "test_tool".to_string()
+        }
+
+        fn description(&self) -> String {
+            "A test tool".to_string()
+        }
+
+        fn parameters(&self) -> Value {
+            json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: &Value) -> Result<Value, ToolError> {
+            Ok(Value::String("mock tool output".to_string()))
+        }
+    }
+
+    #[test]
+    fn test_normalize_arguments_direct_json() {
+        let args = r#"{"key": "value"}"#;
+        let result = ToolExecutor::normalize_arguments(args);
+
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(value.get("key").unwrap().as_str(), Some("value"));
+    }
+
+    #[test]
+    fn test_normalize_arguments_plain_string() {
+        let args = "plain string";
+        let result = ToolExecutor::normalize_arguments(args);
+
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(value.get("input").unwrap().as_str(), Some("plain string"));
+    }
+
+    #[test]
+    fn test_create_result_message() {
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "test_tool".to_string(),
+            arguments: "{}".to_string(),
+        };
+
+        let output = json!({"result": "success"});
+        let msg = ToolExecutor::create_result_message(&call, output);
+
+        assert_eq!(msg.sender, SenderType::Tool);
+        assert!(msg.text.contains("call_1"));
+    }
+
+    #[test]
+    fn test_create_error_message() {
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "test_tool".to_string(),
+            arguments: "{}".to_string(),
+        };
+
+        let error = ToolError::ExecutionError("Tool failed".to_string());
+        let msg = ToolExecutor::create_error_message(&call, &error);
+
+        assert_eq!(msg.sender, SenderType::Tool);
+        assert!(msg.text.contains("error"));
+    }
+
+    #[tokio::test]
+    async fn test_execute() -> Result<()> {
+        let tool = TestTool;
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "test_tool".to_string(),
+            arguments: "{key: 10}".to_string(),
+        };
+
+        let msg = ToolExecutor::execute(&call, &tool).await?;
+
+        assert_eq!(msg.sender, SenderType::Tool);
+        let tool_result: ToolResult = serde_json::from_str(&msg.text)?;
+        assert_eq!(tool_result.call.id, "call_1");
+        assert_eq!(tool_result.output, json!("mock tool output"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_stringified_json_argument() -> Result<()> {
+        struct ArgRecorder;
+        #[async_trait]
+        impl Tool for ArgRecorder {
+            fn name(&self) -> String {
+                "arg_recorder".to_string()
+            }
+
+            fn description(&self) -> String {
+                "Records arguments".to_string()
+            }
+
+            fn parameters(&self) -> Value {
+                json!({})
+            }
+
+            async fn execute(&self, args: &Value) -> std::result::Result<Value, ToolError> {
+                Ok(args.clone())
+            }
+        }
+
+        let tool = ArgRecorder;
+        // The arguments are a string that itself is a JSON object
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "arg_recorder".to_string(),
+            arguments: r#""{\"arg\":42}""#.to_string(),
+        };
+
+        let result = ToolExecutor::execute(&call, &tool).await?;
+
+        // The tool should have received the parsed JSON object: {"arg":42}
+        let tool_result: ToolResult = serde_json::from_str(&result.text)?;
+        assert_eq!(tool_result.output, json!({"arg":42}));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_with_non_json_string() -> Result<()> {
+        struct ArgRecorder;
+        #[async_trait]
+        impl Tool for ArgRecorder {
+            fn name(&self) -> String {
+                "arg_recorder".to_string()
+            }
+
+            fn description(&self) -> String {
+                "Records arguments".to_string()
+            }
+
+            fn parameters(&self) -> Value {
+                json!({})
+            }
+
+            async fn execute(&self, args: &Value) -> std::result::Result<Value, ToolError> {
+                Ok(args.clone())
+            }
+        }
+
+        let tool = ArgRecorder;
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "arg_recorder".to_string(),
+            arguments: "plain string".to_string(),
+        };
+
+        let result = ToolExecutor::execute(&call, &tool).await?;
+
+        // We expect the tool to have received: {"input": "plain string"}
+        let tool_result: ToolResult = serde_json::from_str(&result.text)?;
+        assert_eq!(tool_result.output, json!({ "input": "plain string" }));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_cleans_control_characters() -> Result<()> {
+        #[derive(Debug)]
+        struct ControlCharTool;
+        #[async_trait]
+        impl Tool for ControlCharTool {
+            fn name(&self) -> String {
+                "control_tool".to_string()
+            }
+
+            fn description(&self) -> String {
+                "Tool with control characters".to_string()
+            }
+
+            fn parameters(&self) -> Value {
+                json!({})
+            }
+
+            async fn execute(&self, _args: &Value) -> std::result::Result<Value, ToolError> {
+                // Return value containing control characters
+                Ok(json!({
+                    "key": "value with \u{0001} control \u{001F} characters"
+                }))
+            }
+        }
+
+        let tool = ControlCharTool;
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "control_tool".to_string(),
+            arguments: "{}".to_string(),
+        };
+
+        let result = ToolExecutor::execute(&call, &tool).await?;
+
+        // Check that control characters were removed
+        let tool_result: ToolResult = serde_json::from_str(result.text.as_str())?;
+        let output_str = tool_result.output.get("key").unwrap().as_str().unwrap();
+        assert_eq!(output_str, "value with  control  characters");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_mismatched_name() {
+        let call = ToolCall {
+            id: "call_1".to_string(),
+            name: "different_tool".to_string(),
+            arguments: "{}".to_string(),
+        };
+
+        let tool = TestTool;
+        let result = ToolExecutor::execute(&call, &tool).await;
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/core/tests/gguf_integration.rs
+++ b/crates/core/tests/gguf_integration.rs
@@ -1,4 +1,4 @@
-use arey_core::tools::{Tool, ToolError, ToolResult};
+use arey_core::tools::{Tool, ToolError};
 use arey_core::{
     completion::{CancellationToken, ChatMessage, Completion, CompletionModel, SenderType},
     model::{ModelConfig, ModelProvider},
@@ -22,10 +22,9 @@ const MODEL_FILENAME: &str = "Qwen_Qwen3.5-0.8B-Q4_K_L.gguf";
 
 static DOWNLOAD_ONCE: OnceCell<()> = OnceCell::const_new();
 static TRANSFORMER_DOWNLOAD_ONCE: OnceCell<()> = OnceCell::const_new();
-static MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
-static TRANSFORMER_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
-static TEMPLATE_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
-static OOM_TEST_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
+
+const TRANSFORMER_MODEL_URL: &str = "https://huggingface.co/bartowski/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf";
+const TRANSFORMER_MODEL_FILENAME: &str = "Qwen_Qwen3-0.6B-Q4_K_M.gguf";
 
 fn get_test_data_dir() -> PathBuf {
     if let Ok(dir) = env::var("AREY_TEST_DATA_DIR") {
@@ -67,87 +66,102 @@ async fn get_model_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(model_path)
 }
 
+async fn get_transformer_model_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let data_dir = get_test_data_dir();
+    fs::create_dir_all(&data_dir)?;
+    let model_path = data_dir.join(TRANSFORMER_MODEL_FILENAME);
+
+    TRANSFORMER_DOWNLOAD_ONCE
+        .get_or_init(|| async {
+            if !model_path.exists() {
+                println!(
+                    "Downloading transformer test model from {}...",
+                    TRANSFORMER_MODEL_URL
+                );
+                let response = reqwest::get(TRANSFORMER_MODEL_URL)
+                    .await
+                    .expect("Failed to download test model");
+                let mut dest = fs::File::create(&model_path)
+                    .expect("Failed to create model file for download");
+                let content = response
+                    .bytes()
+                    .await
+                    .expect("Failed to read model bytes from response");
+                copy(&mut content.as_ref(), &mut dest).expect("Failed to write model to file");
+                println!("Transformer model downloaded to {}", model_path.display());
+            }
+        })
+        .await;
+
+    Ok(model_path)
+}
+
 async fn get_shared_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_model_path().await?;
-
-    let model = MODEL_ONCE
-        .get_or_init(|| async {
-            let model_config = get_model_config(&model_path, "shared-gguf-model");
-            Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared model"))
-        })
-        .await
-        .clone();
+    let model_config = get_model_config(&model_path, "shared-gguf-model");
+    let model = GgufBaseModel::new(model_config)?;
     model.reset().await?;
-    Ok(model)
+    Ok(Arc::new(model))
 }
 
-async fn get_shared_transformer_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+async fn create_hybrid_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+    let model_path = get_model_path().await?;
+    let mut settings = HashMap::new();
+    settings.insert("path".to_string(), model_path.to_str().unwrap().into());
+    settings.insert("n_gpu_layers".to_string(), 0.into());
+    settings.insert("n_ctx".to_string(), 1024.into());
+
+    let model_config = ModelConfig {
+        key: "test-hybrid".to_string(),
+        name: "test-hybrid".to_string(),
+        provider: ModelProvider::Gguf,
+        settings,
+    };
+    let model = GgufBaseModel::new(model_config)?;
+    model.reset().await?;
+    Ok(Arc::new(model))
+}
+
+async fn create_transformer_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_transformer_model_path().await?;
+    let mut settings = HashMap::new();
+    settings.insert("path".to_string(), model_path.to_str().unwrap().into());
+    settings.insert("n_gpu_layers".to_string(), 0.into());
+    settings.insert("n_ctx".to_string(), 1024.into());
+    settings.insert("cache_strategy".to_string(), "KvCacheOnly".into());
 
-    let model = TRANSFORMER_MODEL_ONCE
-        .get_or_init(|| async {
-            let model_config = get_model_config_with_strategy(
-                &model_path,
-                "shared-transformer-model",
-                "KvCacheOnly",
-            );
-            Arc::new(
-                GgufBaseModel::new(model_config)
-                    .expect("Failed to create shared transformer model"),
-            )
-        })
-        .await
-        .clone();
+    let model_config = ModelConfig {
+        key: "test-transformer".to_string(),
+        name: "test-transformer".to_string(),
+        provider: ModelProvider::Gguf,
+        settings,
+    };
+    let model = GgufBaseModel::new(model_config)?;
     model.reset().await?;
-    Ok(model)
+    Ok(Arc::new(model))
 }
 
-async fn get_shared_template_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+async fn create_template_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_model_path().await?;
+    let mut settings = HashMap::new();
+    settings.insert("path".to_string(), model_path.to_str().unwrap().into());
+    settings.insert("n_gpu_layers".to_string(), 0.into());
+    settings.insert("n_ctx".to_string(), 1024.into());
+    settings.insert(
+        "template".to_string(),
+        serde_yaml::Value::String("qwen35".to_string()),
+    );
+    settings.insert("cache_strategy".to_string(), "hybrid".into());
 
-    let model = TEMPLATE_MODEL_ONCE
-        .get_or_init(|| async {
-            let mut model_config = get_model_config(&model_path, "shared-template-model");
-            model_config.settings.insert(
-                "template".to_string(),
-                serde_yaml::Value::String("qwen35".to_string()),
-            );
-            model_config
-                .settings
-                .insert("cache_strategy".to_string(), "hybrid".into());
-            Arc::new(
-                GgufBaseModel::new(model_config).expect("Failed to create shared template model"),
-            )
-        })
-        .await
-        .clone();
+    let model_config = ModelConfig {
+        key: "test-template".to_string(),
+        name: "test-template".to_string(),
+        provider: ModelProvider::Gguf,
+        settings,
+    };
+    let model = GgufBaseModel::new(model_config)?;
     model.reset().await?;
-    Ok(model)
-}
-
-async fn get_shared_oom_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
-    let model_path = get_model_path().await?;
-
-    let model = OOM_TEST_MODEL_ONCE
-        .get_or_init(|| async {
-            let mut settings = HashMap::new();
-            settings.insert("path".to_string(), model_path.to_str().unwrap().into());
-            settings.insert("n_gpu_layers".to_string(), 0.into());
-            settings.insert("n_ctx".to_string(), 512.into());
-            settings.insert("n_batch".to_string(), 256.into());
-
-            let model_config = ModelConfig {
-                key: "test-oom".to_string(),
-                name: "shared-oom-model".to_string(),
-                provider: ModelProvider::Gguf,
-                settings,
-            };
-            Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared OOM model"))
-        })
-        .await
-        .clone();
-    model.reset().await?;
-    Ok(model)
+    Ok(Arc::new(model))
 }
 
 fn get_model_config(model_path: &Path, name: &str) -> ModelConfig {
@@ -198,26 +212,18 @@ fn init_tracing() {
     }
 }
 
-#[tokio::test]
-async fn test_gguf_model_complete() {
-    init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let messages = vec![ChatMessage {
-        sender: SenderType::User,
-        text: "Once upon a time,".to_string(),
-        ..Default::default()
-    }];
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
+async fn run_completion(
+    model: &GgufBaseModel,
+    messages: &[ChatMessage],
+    settings: &HashMap<String, String>,
+) -> (String, bool, u32, u32) {
     let mut stream = model
-        .complete(&messages, None, &settings, CancellationToken::new())
+        .complete(messages, None, settings, CancellationToken::new())
         .await;
-
     let mut response_text = String::new();
     let mut finished = false;
+    let mut prompt_tokens = 0;
+    let mut completion_tokens = 0;
     while let Some(result) = stream.next().await {
         match result.unwrap() {
             Completion::Response(resp) => {
@@ -226,61 +232,51 @@ async fn test_gguf_model_complete() {
                     finished = true;
                 }
             }
-            Completion::Metrics(_) => {}
+            Completion::Metrics(m) => {
+                prompt_tokens = m.prompt_tokens;
+                completion_tokens = m.completion_tokens;
+            }
         }
     }
-
-    assert!(finished, "Completion should have finished");
-    assert!(
-        !response_text.is_empty(),
-        "Response text should not be empty"
-    );
+    (response_text, finished, prompt_tokens, completion_tokens)
 }
 
 #[tokio::test]
-async fn test_gguf_streaming_response() {
+async fn test_gguf_completion() {
     init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let messages = vec![ChatMessage {
-        sender: SenderType::User,
-        text: "Say 'hello world'.".to_string(),
-        ..Default::default()
-    }];
+    let model = create_hybrid_model().await.unwrap();
 
     let mut settings = HashMap::new();
     settings.insert("max_tokens".to_string(), "5".to_string());
 
-    let mut stream = model
-        .complete(&messages, None, &settings, CancellationToken::new())
-        .await;
-
-    let mut chunks_received = 0;
-    let mut final_chunk_received = false;
-
-    while let Some(result) = stream.next().await {
-        match result.unwrap() {
-            Completion::Response(resp) => {
-                chunks_received += 1;
-                if resp.finish_reason.is_some() {
-                    final_chunk_received = true;
-                }
-            }
-            Completion::Metrics(m) => {
-                println!(
-                    "Metrics: prompt_tokens={}, completion_tokens={}",
-                    m.prompt_tokens, m.completion_tokens
-                );
-                assert!(m.prompt_tokens > 0, "Should have prompt tokens");
-                assert!(m.completion_tokens > 0, "Should have completion tokens");
-            }
-        }
-    }
-
-    assert!(chunks_received > 0, "Should receive response chunks");
+    // Scenario 1: Basic completion
+    let messages1 = vec![ChatMessage {
+        sender: SenderType::User,
+        text: "Once upon a time,".to_string(),
+        ..Default::default()
+    }];
+    let (text1, finished1, prompt_tok1, completion_tok1) =
+        run_completion(&model, &messages1, &settings).await;
+    assert!(finished1, "Completion should have finished");
+    assert!(!text1.is_empty(), "Response text should not be empty");
     assert!(
-        final_chunk_received,
-        "Should receive final chunk with finish_reason"
+        prompt_tok1 > 0 && completion_tok1 > 0,
+        "Should have prompt and completion tokens"
+    );
+
+    // Scenario 2: Streaming response
+    let messages2 = vec![ChatMessage {
+        sender: SenderType::User,
+        text: "Say 'hello world'.".to_string(),
+        ..Default::default()
+    }];
+    let (text2, finished2, prompt_tok2, completion_tok2) =
+        run_completion(&model, &messages2, &settings).await;
+    assert!(finished2, "Completion 2 should have finished");
+    assert!(!text2.is_empty(), "Response text 2 should not be empty");
+    assert!(
+        prompt_tok2 > 0 && completion_tok2 > 0,
+        "Should have prompt and completion tokens"
     );
 }
 
@@ -315,340 +311,6 @@ async fn complete_and_extract(
         }
     }
     (response_text, cache_metrics)
-}
-
-#[tokio::test]
-async fn test_gguf_hybrid_cache_prefix_match() {
-    init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
-    // Turn 1: First user message (no cache hit expected)
-    let user_msg_1 = ChatMessage {
-        sender: SenderType::User,
-        text: "Say 'hello' if you can hear me.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn1 = vec![user_msg_1.clone()];
-
-    let (response1, cache1) = complete_and_extract(&model, &messages_turn1, &settings).await;
-    println!("Turn 1 response: {}", response1);
-    assert!(!response1.is_empty(), "Turn 1 response should not be empty");
-    assert!(cache1.is_some(), "Cache metrics should be present");
-    assert!(
-        !cache1.as_ref().unwrap().cache_hit,
-        "Turn 1 should NOT be a cache hit"
-    );
-    assert_eq!(
-        cache1.as_ref().unwrap().strategy.as_deref(),
-        Some("Hybrid"),
-        "Strategy should be Hybrid"
-    );
-
-    // Turn 2: Same message (cache hit expected for Hybrid prefix match)
-    let messages_turn2 = vec![user_msg_1.clone()];
-
-    let (response2, cache2) = complete_and_extract(&model, &messages_turn2, &settings).await;
-    println!("Turn 2 response: {}", response2);
-    assert!(!response2.is_empty(), "Turn 2 response should not be empty");
-    assert!(cache2.is_some(), "Cache metrics should be present");
-    assert!(
-        cache2.as_ref().unwrap().cache_hit,
-        "Turn 2 should be a cache hit"
-    );
-
-    // Turn 3: Multi-turn conversation (prefix match)
-    let assistant_msg_1 = ChatMessage {
-        sender: SenderType::Assistant,
-        text: response1,
-        ..Default::default()
-    };
-    let user_msg_2 = ChatMessage {
-        sender: SenderType::User,
-        text: "Who are you?".to_string(),
-        ..Default::default()
-    };
-    let messages_turn3 = vec![user_msg_1.clone(), assistant_msg_1, user_msg_2];
-
-    let (response3, _cache3) = complete_and_extract(&model, &messages_turn3, &settings).await;
-    println!("Turn 3 response: {}", response3);
-    assert!(!response3.is_empty(), "Turn 3 response should not be empty");
-
-    // Turn 4: Different conversation (should NOT hit cache)
-    let different_user_msg = ChatMessage {
-        sender: SenderType::User,
-        text: "Say 'goodbye' if you can hear me.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn4 = vec![different_user_msg];
-
-    let (response4, cache4) = complete_and_extract(&model, &messages_turn4, &settings).await;
-    println!("Turn 4 response: {}", response4);
-    assert!(!response4.is_empty(), "Turn 4 response should not be empty");
-    assert!(cache4.is_some(), "Cache metrics should be present");
-    assert!(
-        !cache4.as_ref().unwrap().cache_hit,
-        "Turn 4 should NOT be a cache hit"
-    );
-}
-
-#[tokio::test]
-async fn test_gguf_hybrid_cache_with_output_fields() {
-    init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
-    // Turn 1: First user message
-    let user_msg_1 = ChatMessage {
-        sender: SenderType::User,
-        text: "Say 'hello' if you can hear me.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn1 = vec![user_msg_1.clone()];
-
-    let (response1, _) = complete_and_extract(&model, &messages_turn1, &settings).await;
-    println!("Turn 1 response: {}", response1);
-    assert!(!response1.is_empty(), "Turn 1 response should not be empty");
-
-    // Turn 2: Multi-turn with assistant message containing tools/metrics
-    let assistant_msg_with_output = ChatMessage {
-        sender: SenderType::Assistant,
-        text: response1,
-        tools: Some(vec![]),
-        metrics: Some(arey_core::completion::CompletionMetrics {
-            prompt_tokens: 22,
-            prompt_eval_latency_ms: 100.0,
-            completion_tokens: 10,
-            completion_latency_ms: 500.0,
-            thought: None,
-            raw_chunk: None,
-            cache_metrics: None,
-        }),
-        ..Default::default()
-    };
-    let user_msg_2 = ChatMessage {
-        sender: SenderType::User,
-        text: "Who are you?".to_string(),
-        ..Default::default()
-    };
-    let messages_turn2 = vec![user_msg_1.clone(), assistant_msg_with_output, user_msg_2];
-
-    let (response2, _) = complete_and_extract(&model, &messages_turn2, &settings).await;
-    println!("Turn 2 response: {}", response2);
-    assert!(!response2.is_empty(), "Turn 2 response should not be empty");
-}
-
-#[tokio::test]
-async fn test_gguf_auto_detect_cache_strategy() {
-    init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
-    let messages = vec![ChatMessage {
-        sender: SenderType::User,
-        text: "Hello".to_string(),
-        ..Default::default()
-    }];
-
-    let mut stream = model
-        .complete(&messages, None, &settings, CancellationToken::new())
-        .await;
-
-    let mut completed = false;
-    while let Some(result) = stream.next().await {
-        match result {
-            Ok(Completion::Response(_)) => {}
-            Ok(Completion::Metrics(m)) => {
-                println!(
-                    "  Cache metrics: strategy={:?}",
-                    m.cache_metrics.as_ref().map(|c| &c.strategy)
-                );
-                assert!(m.cache_metrics.is_some(), "Cache metrics should be present");
-                let cache = m.cache_metrics.unwrap();
-                assert!(cache.strategy.is_some(), "Strategy should be detected");
-                let strategy = cache.strategy.unwrap();
-                assert_eq!(
-                    strategy, "Hybrid",
-                    "Qwen3.5 should auto-detect as Hybrid strategy"
-                );
-                completed = true;
-            }
-            Err(e) => panic!("Stream error: {}", e),
-        }
-    }
-    assert!(completed, "Should have received metrics");
-}
-
-#[tokio::test]
-async fn test_gguf_cache_mechanism() {
-    init_tracing();
-    let model = get_shared_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
-    let long_prompt = "Explain the concept of recursion in computer science.";
-
-    let user_msg = ChatMessage {
-        sender: SenderType::User,
-        text: long_prompt.to_string(),
-        ..Default::default()
-    };
-    let messages = vec![user_msg.clone()];
-
-    // First run: Create the cache snapshot
-    let (first_response, first_metrics) = complete_and_extract(&model, &messages, &settings).await;
-
-    assert!(
-        !first_response.is_empty(),
-        "First response should not be empty"
-    );
-    assert!(first_metrics.is_some(), "First metrics should be present");
-    let first_cache = first_metrics.as_ref().unwrap();
-    println!(
-        "First run: prompt_tokens={}, cache_hit={}",
-        first_cache.tokens_skipped.unwrap_or(0),
-        first_cache.cache_hit
-    );
-
-    // Second run: Should hit the cache
-    let (second_response, second_metrics) =
-        complete_and_extract(&model, &messages, &settings).await;
-
-    assert!(
-        !second_response.is_empty(),
-        "Second response should not be empty"
-    );
-    assert!(second_metrics.is_some(), "Second metrics should be present");
-
-    let second_cache = second_metrics.as_ref().unwrap();
-    println!("Second run: cache_hit={}", second_cache.cache_hit);
-
-    // Verify cache hit occurred
-    assert!(second_cache.cache_hit, "Second run should be a cache hit");
-}
-
-const TRANSFORMER_MODEL_URL: &str = "https://huggingface.co/bartowski/Qwen_Qwen3-0.6B-GGUF/resolve/main/Qwen_Qwen3-0.6B-Q4_K_M.gguf";
-const TRANSFORMER_MODEL_FILENAME: &str = "Qwen_Qwen3-0.6B-Q4_K_M.gguf";
-
-async fn get_transformer_model_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let data_dir = get_test_data_dir();
-    fs::create_dir_all(&data_dir)?;
-    let model_path = data_dir.join(TRANSFORMER_MODEL_FILENAME);
-
-    TRANSFORMER_DOWNLOAD_ONCE
-        .get_or_init(|| async {
-            if !model_path.exists() {
-                println!(
-                    "Downloading transformer test model from {}...",
-                    TRANSFORMER_MODEL_URL
-                );
-                let response = reqwest::get(TRANSFORMER_MODEL_URL)
-                    .await
-                    .expect("Failed to download test model");
-                let mut dest = fs::File::create(&model_path)
-                    .expect("Failed to create model file for download");
-                let content = response
-                    .bytes()
-                    .await
-                    .expect("Failed to read model bytes from response");
-                copy(&mut content.as_ref(), &mut dest).expect("Failed to write model to file");
-                println!("Transformer model downloaded to {}", model_path.display());
-            }
-        })
-        .await;
-
-    Ok(model_path)
-}
-
-#[tokio::test]
-async fn test_gguf_transformer_kv_cache() {
-    init_tracing();
-    let model = get_shared_transformer_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "5".to_string());
-
-    // First request - use longer message (>8 tokens) to exceed cache threshold
-    let user_msg_1 = ChatMessage {
-        sender: SenderType::User,
-        text: "Please say hello if you can hear me, this is a test message.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn1 = vec![user_msg_1.clone()];
-
-    let (response1, cache1) = complete_and_extract(&model, &messages_turn1, &settings).await;
-    println!("Turn 1 response: {}", response1);
-    assert!(!response1.is_empty(), "Turn 1 response should not be empty");
-    assert!(cache1.is_some(), "Cache metrics should be present");
-    assert!(
-        !cache1.as_ref().unwrap().cache_hit,
-        "Turn 1 should NOT be a cache hit"
-    );
-    assert_eq!(
-        cache1.as_ref().unwrap().strategy.as_deref(),
-        Some("KvCacheOnly"),
-        "Strategy should be KvCacheOnly"
-    );
-
-    // Second request with same message - should hit KV cache
-    let messages_turn2 = vec![user_msg_1.clone()];
-
-    let (response2, cache2) = complete_and_extract(&model, &messages_turn2, &settings).await;
-    println!("Turn 2 response: {}", response2);
-    assert!(!response2.is_empty(), "Turn 2 response should not be empty");
-    assert!(cache2.is_some(), "Cache metrics should be present");
-    assert!(
-        cache2.as_ref().unwrap().cache_hit,
-        "Turn 2 should be a cache hit (KvCacheOnly)"
-    );
-
-    // Verify tokens were skipped
-    let tokens_skipped = cache2.as_ref().unwrap().tokens_skipped;
-    assert!(
-        tokens_skipped.is_some(),
-        "Should have tokens_skipped for KvCacheOnly"
-    );
-    println!("Turn 2 tokens_skipped: {:?}", tokens_skipped);
-
-    // Third request with different message - after overflow, should NOT hit cache
-    let user_msg_2 = ChatMessage {
-        sender: SenderType::User,
-        text: "Please say goodbye if you can hear me, this is another test.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn3 = vec![user_msg_2];
-
-    let (response3, cache3) = complete_and_extract(&model, &messages_turn3, &settings).await;
-    println!("Turn 3 response: {}", response3);
-    assert!(!response3.is_empty(), "Turn 3 response should not be empty");
-    assert!(cache3.is_some(), "Cache metrics should be present");
-    // After overflow, should be no cache hit
-    assert!(
-        !cache3.as_ref().unwrap().cache_hit,
-        "Turn 3 should NOT be a cache hit after overflow"
-    );
-
-    // Fourth request with completely different message - should NOT hit cache
-    let user_msg_3 = ChatMessage {
-        sender: SenderType::User,
-        text: "What is the capital of France? Please answer.".to_string(),
-        ..Default::default()
-    };
-    let messages_turn4 = vec![user_msg_3];
-
-    let (response4, cache4) = complete_and_extract(&model, &messages_turn4, &settings).await;
-    println!("Turn 4 response: {}", response4);
-    assert!(!response4.is_empty(), "Turn 4 response should not be empty");
-    assert!(cache4.is_some(), "Cache metrics should be present");
-    // After overflow, should be no cache hit
-    println!("Turn 4 cache_hit={}", cache4.as_ref().unwrap().cache_hit);
 }
 
 struct WeatherTool;
@@ -731,168 +393,6 @@ async fn complete_with_tools(
         }
     }
     (response_text, thought, tool_calls, cache_metrics)
-}
-
-#[tokio::test]
-async fn test_gguf_hybrid_cache_with_tool_calls() {
-    init_tracing();
-    let model = get_shared_template_model().await.unwrap();
-
-    let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "10".to_string());
-
-    let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(WeatherTool)];
-    let mut messages: Vec<ChatMessage> = Vec::new();
-
-    // Turn 1: First user message (no cache hit expected)
-    let user_msg_1 = ChatMessage {
-        sender: SenderType::User,
-        text: "Hello, what is the weather like?".to_string(),
-        ..Default::default()
-    };
-    messages.clear();
-    messages.push(user_msg_1.clone());
-
-    let (response1, thought1, _tool_calls1, cache1) =
-        complete_with_tools(&model, &messages, &tools, &settings).await;
-    println!("Turn 1 response: {}", response1);
-    println!("Turn 1 thought: {:?}", thought1);
-    assert!(!response1.is_empty(), "Turn 1 response should not be empty");
-    assert!(cache1.is_some(), "Cache metrics should be present");
-    assert!(
-        !cache1.as_ref().unwrap().cache_hit,
-        "Turn 1 should NOT be a cache hit"
-    );
-
-    // Turn 2: Same message (cache hit expected for Hybrid prefix match)
-    messages.clear();
-    messages.push(user_msg_1.clone());
-
-    let (response2, _thought2, _tool_calls2, cache2) =
-        complete_with_tools(&model, &messages, &tools, &settings).await;
-    println!("Turn 2 response: {}", response2);
-    println!(
-        "Turn 2 cache_hit={}, transition={:?}",
-        cache2.as_ref().map(|c| c.cache_hit).unwrap_or(false),
-        cache2
-            .as_ref()
-            .and_then(|c| c.checkpoint_transition.clone())
-    );
-    assert!(!response2.is_empty(), "Turn 2 response should not be empty");
-    assert!(cache2.is_some(), "Cache metrics should be present");
-    assert!(
-        cache2.as_ref().unwrap().cache_hit,
-        "Turn 2 should be a cache hit"
-    );
-
-    // Turn 3: Multi-turn conversation (cache hit via TurnEnd checkpoint)
-    let assistant_msg_1 = ChatMessage {
-        sender: SenderType::Assistant,
-        text: response1.clone(),
-        thought: thought1.clone(),
-        ..Default::default()
-    };
-    let user_msg_2 = ChatMessage {
-        sender: SenderType::User,
-        text: "Thanks, that's helpful!".to_string(),
-        ..Default::default()
-    };
-    messages.clear();
-    messages.push(user_msg_1.clone());
-    messages.push(assistant_msg_1.clone());
-    messages.push(user_msg_2.clone());
-
-    let (response3, thought3, _tool_calls3, cache3) =
-        complete_with_tools(&model, &messages, &tools, &settings).await;
-    println!("Turn 3 response: {}", response3);
-    println!("Turn 3 thought: {:?}", thought3);
-    println!(
-        "Turn 3 cache_hit={}, transition={:?}",
-        cache3.as_ref().map(|c| c.cache_hit).unwrap_or(false),
-        cache3
-            .as_ref()
-            .and_then(|c| c.checkpoint_transition.clone())
-    );
-    assert!(!response3.is_empty(), "Turn 3 response should not be empty");
-    assert!(cache3.is_some(), "Cache metrics should be present");
-
-    // Turn 4: Tool call scenario - user asks for weather, model makes tool call
-    let user_msg_3 = ChatMessage {
-        sender: SenderType::User,
-        text: "What's the weather in Tokyo?".to_string(),
-        ..Default::default()
-    };
-    let assistant_msg_3 = ChatMessage {
-        sender: SenderType::Assistant,
-        text: response3.clone(),
-        thought: thought3.clone(),
-        ..Default::default()
-    };
-    messages.clear();
-    messages.push(user_msg_1.clone());
-    messages.push(assistant_msg_1);
-    messages.push(user_msg_2.clone());
-    messages.push(assistant_msg_3);
-    messages.push(user_msg_3.clone());
-
-    let (response4, _thought4, tool_calls4, cache4) =
-        complete_with_tools(&model, &messages, &tools, &settings).await;
-    println!("Turn 4 response: {}", response4);
-    println!("Turn 4 tool_calls: {:?}", tool_calls4);
-
-    // The model might or might not make a tool call depending on its behavior
-    // But we should still get a response
-    if let Some(calls) = tool_calls4.filter(|c| !c.is_empty()) {
-        println!(
-            "Tool call detected: {}({:?})",
-            calls[0].name, calls[0].arguments
-        );
-
-        // Execute the tool
-        let tool = tools
-            .iter()
-            .find(|t| t.name() == calls[0].name)
-            .expect("Tool not found");
-        let args: serde_json::Value =
-            serde_json::from_str(&calls[0].arguments).expect("Invalid tool arguments");
-        let output = tool.execute(&args).await.expect("Tool execution failed");
-        println!("Tool output: {}", output);
-
-        // Add tool result message (this tests ToolResponse checkpoint transition)
-        let tool_result_msg = ChatMessage {
-            sender: SenderType::Tool,
-            text: serde_json::to_string(&ToolResult {
-                call: calls[0].clone(),
-                output,
-            })
-            .unwrap(),
-            ..Default::default()
-        };
-        messages.push(tool_result_msg);
-
-        // Continue with tool results for final response
-        let (response5, _thought5, _tool_calls5, cache5) =
-            complete_with_tools(&model, &messages, &tools, &settings).await;
-        println!("Turn 5 (after tool) response: {}", response5);
-        assert!(!response5.is_empty(), "Turn 5 response should not be empty");
-        assert!(cache5.is_some(), "Cache metrics should be present");
-        println!(
-            "Turn 5 cache_hit={}, transition={:?}",
-            cache5.as_ref().unwrap().cache_hit,
-            cache5.as_ref().unwrap().checkpoint_transition
-        );
-    }
-
-    // Verify cache metrics for Turn 4
-    assert!(
-        cache4.is_some(),
-        "Cache metrics should be present for Turn 4"
-    );
-    println!(
-        "Turn 4 cache_hit={}, transition={:?}",
-        cache4.as_ref().unwrap().cache_hit,
-        cache4.as_ref().unwrap().checkpoint_transition
-    );
 }
 
 #[tokio::test]
@@ -991,7 +491,20 @@ async fn test_oom_recovery_with_trim() {
     init_tracing();
 
     // Create a dedicated model with small context for OOM testing
-    let model = get_shared_oom_model().await.unwrap();
+    let model_path = get_model_path().await.unwrap();
+    let mut settings = HashMap::new();
+    settings.insert("path".to_string(), model_path.to_str().unwrap().into());
+    settings.insert("n_gpu_layers".to_string(), 0.into());
+    settings.insert("n_ctx".to_string(), 512.into());
+    settings.insert("n_batch".to_string(), 256.into());
+
+    let model_config = ModelConfig {
+        key: "test-oom".to_string(),
+        name: "test-oom".to_string(),
+        provider: ModelProvider::Gguf,
+        settings,
+    };
+    let model = GgufBaseModel::new(model_config).unwrap();
 
     // Add many messages to fill context - use repetitive text to quickly fill
     // Use smaller repeated text to fit within 512 context without exceeding
@@ -1047,4 +560,243 @@ async fn test_oom_recovery_with_trim() {
     );
 
     assert!(received_response, "Should receive response");
+}
+
+#[tokio::test]
+async fn test_hybrid_cache() {
+    init_tracing();
+
+    let model = create_hybrid_model().await.unwrap();
+
+    let mut settings = HashMap::new();
+    settings.insert("max_tokens".to_string(), "5".to_string());
+
+    // === Scenario 1: Turn 1 should NOT be cache hit ===
+    let user_msg_1 = ChatMessage {
+        sender: SenderType::User,
+        text: "Say 'hello' if you can hear me.".to_string(),
+        ..Default::default()
+    };
+
+    let (response1, cache1) =
+        complete_and_extract(&model, std::slice::from_ref(&user_msg_1), &settings).await;
+    println!(
+        "Turn 1: response='{}', cache_hit={}",
+        response1,
+        cache1.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(!response1.is_empty());
+    assert!(
+        !cache1.as_ref().unwrap().cache_hit,
+        "Turn 1 should NOT be cache hit"
+    );
+    assert_eq!(cache1.as_ref().unwrap().strategy.as_deref(), Some("Hybrid"));
+
+    // === Scenario 2: Same message should cache hit ===
+    let (_response2, cache2) =
+        complete_and_extract(&model, std::slice::from_ref(&user_msg_1), &settings).await;
+    println!(
+        "Turn 2: cache_hit={}",
+        cache2.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        cache2.as_ref().unwrap().cache_hit,
+        "Turn 2 should be cache hit"
+    );
+
+    // === Scenario 3: Multi-turn prefix match ===
+    let assistant_msg_1 = ChatMessage {
+        sender: SenderType::Assistant,
+        text: response1.clone(),
+        ..Default::default()
+    };
+    let user_msg_2 = ChatMessage {
+        sender: SenderType::User,
+        text: "Who are you?".to_string(),
+        ..Default::default()
+    };
+    let messages_turn3 = vec![user_msg_1.clone(), assistant_msg_1, user_msg_2];
+    let (response3, cache3) = complete_and_extract(&model, &messages_turn3, &settings).await;
+    println!(
+        "Turn 3: cache_hit={}",
+        cache3.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(!response3.is_empty());
+
+    // === Scenario 4: Different conversation should NOT cache hit ===
+    let user_msg_4 = ChatMessage {
+        sender: SenderType::User,
+        text: "Say 'goodbye' if you can hear me.".to_string(),
+        ..Default::default()
+    };
+    let (_response4, cache4) = complete_and_extract(&model, &[user_msg_4], &settings).await;
+    println!(
+        "Turn 4: cache_hit={}",
+        cache4.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        !cache4.as_ref().unwrap().cache_hit,
+        "Turn 4 should NOT be cache hit"
+    );
+
+    // === Scenario 5: Auto-detect strategy ===
+    let messages = vec![ChatMessage {
+        sender: SenderType::User,
+        text: "Hello".to_string(),
+        ..Default::default()
+    }];
+    let mut stream = model
+        .complete(&messages, None, &settings, CancellationToken::new())
+        .await;
+    let mut strategy_detected = None;
+    while let Some(result) = stream.next().await {
+        if let Ok(Completion::Metrics(m)) = result
+            && let Some(cm) = m.cache_metrics
+        {
+            strategy_detected = cm.strategy.clone();
+        }
+    }
+    assert_eq!(
+        strategy_detected.as_deref(),
+        Some("Hybrid"),
+        "Should auto-detect Hybrid"
+    );
+
+    // === Scenario 6: Cache mechanism (long prompt) ===
+    let long_prompt = "Explain the concept of recursion in computer science.";
+    let (_first_response, first_cache) = complete_and_extract(
+        &model,
+        &[ChatMessage {
+            sender: SenderType::User,
+            text: long_prompt.to_string(),
+            ..Default::default()
+        }],
+        &settings,
+    )
+    .await;
+    println!(
+        "Long prompt run 1: cache_hit={}",
+        first_cache.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+
+    let (_second_response, second_cache) = complete_and_extract(
+        &model,
+        &[ChatMessage {
+            sender: SenderType::User,
+            text: long_prompt.to_string(),
+            ..Default::default()
+        }],
+        &settings,
+    )
+    .await;
+    println!(
+        "Long prompt run 2: cache_hit={}",
+        second_cache.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        second_cache.as_ref().unwrap().cache_hit,
+        "Second run should be cache hit"
+    );
+}
+
+#[tokio::test]
+async fn test_kvonly_cache() {
+    init_tracing();
+
+    // === Scenario 1: Transformer model with KvCacheOnly ===
+    let transformer_model = create_transformer_model().await.unwrap();
+
+    let mut settings = HashMap::new();
+    settings.insert("max_tokens".to_string(), "5".to_string());
+
+    let user_msg_1 = ChatMessage {
+        sender: SenderType::User,
+        text: "Please say hello if you can hear me, this is a test message.".to_string(),
+        ..Default::default()
+    };
+
+    let (response1, cache1) = complete_and_extract(
+        &transformer_model,
+        std::slice::from_ref(&user_msg_1),
+        &settings,
+    )
+    .await;
+    println!(
+        "Turn 1 (KvCacheOnly): cache_hit={}",
+        cache1.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(!response1.is_empty());
+    assert!(
+        !cache1.as_ref().unwrap().cache_hit,
+        "Turn 1 should NOT cache hit"
+    );
+    assert_eq!(
+        cache1.as_ref().unwrap().strategy.as_deref(),
+        Some("KvCacheOnly")
+    );
+
+    // === Scenario 2: Same message hits KV cache ===
+    let (_response2, cache2) = complete_and_extract(
+        &transformer_model,
+        std::slice::from_ref(&user_msg_1),
+        &settings,
+    )
+    .await;
+    println!(
+        "Turn 2 (KvCacheOnly): cache_hit={}",
+        cache2.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        cache2.as_ref().unwrap().cache_hit,
+        "Turn 2 should cache hit"
+    );
+
+    // === Scenario 3: Different message after overflow should NOT hit ===
+    let user_msg_2 = ChatMessage {
+        sender: SenderType::User,
+        text: "Please say goodbye if you can hear me, this is another test.".to_string(),
+        ..Default::default()
+    };
+    let (_response3, cache3) =
+        complete_and_extract(&transformer_model, &[user_msg_2], &settings).await;
+    println!(
+        "Turn 3 (KvCacheOnly): cache_hit={}",
+        cache3.as_ref().map(|c| c.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        !cache3.as_ref().unwrap().cache_hit,
+        "After overflow should NOT cache hit"
+    );
+
+    // === Scenario 4: Tool calls with hybrid (template model) ===
+    let _template_model = create_template_model().await.unwrap();
+    settings.insert("max_tokens".to_string(), "10".to_string());
+
+    let tool_model = create_template_model().await.unwrap();
+    let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(WeatherTool)];
+
+    // Turn 1: no cache hit
+    let msg1 = ChatMessage {
+        sender: SenderType::User,
+        text: "Hello, what is the weather like?".to_string(),
+        ..Default::default()
+    };
+    let (_r1, _t1, _tc1, c1) =
+        complete_with_tools(&tool_model, std::slice::from_ref(&msg1), &tools, &settings).await;
+    println!(
+        "Tool call turn 1: cache_hit={}",
+        c1.as_ref().map(|x| x.cache_hit).unwrap_or(false)
+    );
+    assert!(
+        !c1.as_ref().unwrap().cache_hit,
+        "Turn 1 should NOT cache hit"
+    );
+
+    // Turn 2: same message should cache hit
+    let (_r2, _t2, _tc2, c2) = complete_with_tools(&tool_model, &[msg1], &tools, &settings).await;
+    println!(
+        "Tool call turn 2: cache_hit={}",
+        c2.as_ref().map(|x| x.cache_hit).unwrap_or(false)
+    );
+    assert!(c2.as_ref().unwrap().cache_hit, "Turn 2 should cache hit");
 }

--- a/crates/core/tests/gguf_integration.rs
+++ b/crates/core/tests/gguf_integration.rs
@@ -70,19 +70,21 @@ async fn get_model_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
 async fn get_shared_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_model_path().await?;
 
-    Ok(MODEL_ONCE
+    let model = MODEL_ONCE
         .get_or_init(|| async {
             let model_config = get_model_config(&model_path, "shared-gguf-model");
             Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared model"))
         })
         .await
-        .clone())
+        .clone();
+    model.reset().await?;
+    Ok(model)
 }
 
 async fn get_shared_transformer_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_transformer_model_path().await?;
 
-    Ok(TRANSFORMER_MODEL_ONCE
+    let model = TRANSFORMER_MODEL_ONCE
         .get_or_init(|| async {
             let model_config = get_model_config_with_strategy(
                 &model_path,
@@ -95,13 +97,15 @@ async fn get_shared_transformer_model() -> Result<Arc<GgufBaseModel>, Box<dyn st
             )
         })
         .await
-        .clone())
+        .clone();
+    model.reset().await?;
+    Ok(model)
 }
 
 async fn get_shared_template_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_model_path().await?;
 
-    Ok(TEMPLATE_MODEL_ONCE
+    let model = TEMPLATE_MODEL_ONCE
         .get_or_init(|| async {
             let mut model_config = get_model_config(&model_path, "shared-template-model");
             model_config.settings.insert(
@@ -116,13 +120,15 @@ async fn get_shared_template_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::
             )
         })
         .await
-        .clone())
+        .clone();
+    model.reset().await?;
+    Ok(model)
 }
 
 async fn get_shared_oom_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
     let model_path = get_model_path().await?;
 
-    Ok(OOM_TEST_MODEL_ONCE
+    let model = OOM_TEST_MODEL_ONCE
         .get_or_init(|| async {
             let mut settings = HashMap::new();
             settings.insert("path".to_string(), model_path.to_str().unwrap().into());
@@ -139,7 +145,9 @@ async fn get_shared_oom_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error
             Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared OOM model"))
         })
         .await
-        .clone())
+        .clone();
+    model.reset().await?;
+    Ok(model)
 }
 
 fn get_model_config(model_path: &Path, name: &str) -> ModelConfig {
@@ -313,7 +321,6 @@ async fn complete_and_extract(
 async fn test_gguf_hybrid_cache_prefix_match() {
     init_tracing();
     let model = get_shared_model().await.unwrap();
-    model.reset().await.unwrap();
 
     let mut settings = HashMap::new();
     settings.insert("max_tokens".to_string(), "5".to_string());
@@ -482,7 +489,6 @@ async fn test_gguf_auto_detect_cache_strategy() {
 async fn test_gguf_cache_mechanism() {
     init_tracing();
     let model = get_shared_model().await.unwrap();
-    model.reset().await.unwrap();
 
     let mut settings = HashMap::new();
     settings.insert("max_tokens".to_string(), "5".to_string());

--- a/crates/core/tests/gguf_integration.rs
+++ b/crates/core/tests/gguf_integration.rs
@@ -22,6 +22,10 @@ const MODEL_FILENAME: &str = "Qwen_Qwen3.5-0.8B-Q4_K_L.gguf";
 
 static DOWNLOAD_ONCE: OnceCell<()> = OnceCell::const_new();
 static TRANSFORMER_DOWNLOAD_ONCE: OnceCell<()> = OnceCell::const_new();
+static MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
+static TRANSFORMER_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
+static TEMPLATE_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
+static OOM_TEST_MODEL_ONCE: OnceCell<Arc<GgufBaseModel>> = OnceCell::const_new();
 
 fn get_test_data_dir() -> PathBuf {
     if let Ok(dir) = env::var("AREY_TEST_DATA_DIR") {
@@ -63,6 +67,81 @@ async fn get_model_path() -> Result<PathBuf, Box<dyn std::error::Error>> {
     Ok(model_path)
 }
 
+async fn get_shared_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+    let model_path = get_model_path().await?;
+
+    Ok(MODEL_ONCE
+        .get_or_init(|| async {
+            let model_config = get_model_config(&model_path, "shared-gguf-model");
+            Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared model"))
+        })
+        .await
+        .clone())
+}
+
+async fn get_shared_transformer_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+    let model_path = get_transformer_model_path().await?;
+
+    Ok(TRANSFORMER_MODEL_ONCE
+        .get_or_init(|| async {
+            let model_config = get_model_config_with_strategy(
+                &model_path,
+                "shared-transformer-model",
+                "KvCacheOnly",
+            );
+            Arc::new(
+                GgufBaseModel::new(model_config)
+                    .expect("Failed to create shared transformer model"),
+            )
+        })
+        .await
+        .clone())
+}
+
+async fn get_shared_template_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+    let model_path = get_model_path().await?;
+
+    Ok(TEMPLATE_MODEL_ONCE
+        .get_or_init(|| async {
+            let mut model_config = get_model_config(&model_path, "shared-template-model");
+            model_config.settings.insert(
+                "template".to_string(),
+                serde_yaml::Value::String("qwen35".to_string()),
+            );
+            model_config
+                .settings
+                .insert("cache_strategy".to_string(), "hybrid".into());
+            Arc::new(
+                GgufBaseModel::new(model_config).expect("Failed to create shared template model"),
+            )
+        })
+        .await
+        .clone())
+}
+
+async fn get_shared_oom_model() -> Result<Arc<GgufBaseModel>, Box<dyn std::error::Error>> {
+    let model_path = get_model_path().await?;
+
+    Ok(OOM_TEST_MODEL_ONCE
+        .get_or_init(|| async {
+            let mut settings = HashMap::new();
+            settings.insert("path".to_string(), model_path.to_str().unwrap().into());
+            settings.insert("n_gpu_layers".to_string(), 0.into());
+            settings.insert("n_ctx".to_string(), 512.into());
+            settings.insert("n_batch".to_string(), 256.into());
+
+            let model_config = ModelConfig {
+                key: "test-oom".to_string(),
+                name: "shared-oom-model".to_string(),
+                provider: ModelProvider::Gguf,
+                settings,
+            };
+            Arc::new(GgufBaseModel::new(model_config).expect("Failed to create shared OOM model"))
+        })
+        .await
+        .clone())
+}
+
 fn get_model_config(model_path: &Path, name: &str) -> ModelConfig {
     let mut settings = HashMap::new();
     settings.insert("path".to_string(), model_path.to_str().unwrap().into());
@@ -77,6 +156,7 @@ fn get_model_config(model_path: &Path, name: &str) -> ModelConfig {
     }
 }
 
+#[allow(dead_code)]
 fn get_model_config_with_strategy(
     model_path: &Path,
     name: &str,
@@ -89,6 +169,7 @@ fn get_model_config_with_strategy(
     config
 }
 
+#[allow(dead_code)]
 fn get_model_config_with_template(
     model_path: &Path,
     name: &str,
@@ -112,16 +193,7 @@ fn init_tracing() {
 #[tokio::test]
 async fn test_gguf_model_complete() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let model_config = get_model_config(&model_path, "test-gguf-complete");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
 
     let messages = vec![ChatMessage {
         sender: SenderType::User,
@@ -160,16 +232,7 @@ async fn test_gguf_model_complete() {
 #[tokio::test]
 async fn test_gguf_streaming_response() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let model_config = get_model_config(&model_path, "test-gguf-streaming");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
 
     let messages = vec![ChatMessage {
         sender: SenderType::User,
@@ -178,7 +241,7 @@ async fn test_gguf_streaming_response() {
     }];
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "10".to_string());
+    settings.insert("max_tokens".to_string(), "5".to_string());
 
     let mut stream = model
         .complete(&messages, None, &settings, CancellationToken::new())
@@ -249,20 +312,11 @@ async fn complete_and_extract(
 #[tokio::test]
 async fn test_gguf_hybrid_cache_prefix_match() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let model_config =
-        get_model_config_with_strategy(&model_path, "test-gguf-hybrid-cache", "hybrid");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
+    model.reset().await.unwrap();
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "10".to_string());
+    settings.insert("max_tokens".to_string(), "5".to_string());
 
     // Turn 1: First user message (no cache hit expected)
     let user_msg_1 = ChatMessage {
@@ -336,20 +390,10 @@ async fn test_gguf_hybrid_cache_prefix_match() {
 #[tokio::test]
 async fn test_gguf_hybrid_cache_with_output_fields() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let model_config =
-        get_model_config_with_strategy(&model_path, "test-gguf-hybrid-cache-fields", "hybrid");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "10".to_string());
+    settings.insert("max_tokens".to_string(), "5".to_string());
 
     // Turn 1: First user message
     let user_msg_1 = ChatMessage {
@@ -394,17 +438,7 @@ async fn test_gguf_hybrid_cache_with_output_fields() {
 #[tokio::test]
 async fn test_gguf_auto_detect_cache_strategy() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    // Don't set cache_strategy - should auto-detect based on model type
-    let model_config = get_model_config(&model_path, "test-gguf-auto-detect");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
 
     let mut settings = HashMap::new();
     settings.insert("max_tokens".to_string(), "5".to_string());
@@ -447,19 +481,11 @@ async fn test_gguf_auto_detect_cache_strategy() {
 #[tokio::test]
 async fn test_gguf_cache_mechanism() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let model_config = get_model_config_with_strategy(&model_path, "test-gguf-cache-perf", "auto");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_model().await.unwrap();
+    model.reset().await.unwrap();
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "20".to_string());
+    settings.insert("max_tokens".to_string(), "5".to_string());
 
     let long_prompt = "Explain the concept of recursion in computer science.";
 
@@ -538,21 +564,10 @@ async fn get_transformer_model_path() -> Result<PathBuf, Box<dyn std::error::Err
 #[tokio::test]
 async fn test_gguf_transformer_kv_cache() {
     init_tracing();
-
-    let model_path = match get_transformer_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    // Use KvCacheOnly strategy for regular transformer model
-    let model_config =
-        get_model_config_with_strategy(&model_path, "test-gguf-transformer-cache", "KvCacheOnly");
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_transformer_model().await.unwrap();
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "10".to_string());
+    settings.insert("max_tokens".to_string(), "5".to_string());
 
     // First request - use longer message (>8 tokens) to exceed cache threshold
     let user_msg_1 = ChatMessage {
@@ -715,23 +730,10 @@ async fn complete_with_tools(
 #[tokio::test]
 async fn test_gguf_hybrid_cache_with_tool_calls() {
     init_tracing();
-
-    let model_path = match get_model_path().await {
-        Ok(path) => path,
-        Err(e) => {
-            panic!("Failed to download test model: {}", e);
-        }
-    };
-
-    let mut model_config =
-        get_model_config_with_template(&model_path, "test-gguf-hybrid-cache-tools", "qwen35");
-    model_config
-        .settings
-        .insert("cache_strategy".to_string(), "hybrid".into());
-    let model = GgufBaseModel::new(model_config).unwrap();
+    let model = get_shared_template_model().await.unwrap();
 
     let mut settings = HashMap::new();
-    settings.insert("max_tokens".to_string(), "20".to_string());
+    settings.insert("max_tokens".to_string(), "10".to_string());
 
     let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(WeatherTool)];
     let mut messages: Vec<ChatMessage> = Vec::new();
@@ -885,4 +887,158 @@ async fn test_gguf_hybrid_cache_with_tool_calls() {
         cache4.as_ref().unwrap().cache_hit,
         cache4.as_ref().unwrap().checkpoint_transition
     );
+}
+
+#[tokio::test]
+async fn test_model_params() {
+    // Skip on CI (GitHub Actions sets CI=true)
+    if std::env::var("CI").is_ok() {
+        eprintln!("Skipping test_model_params on CI");
+        return;
+    }
+
+    init_tracing();
+    let model = get_shared_model().await.unwrap();
+
+    let settings = HashMap::new();
+    let messages = vec![ChatMessage {
+        sender: SenderType::User,
+        text: "hi".to_string(),
+        ..Default::default()
+    }];
+
+    // Trigger model load by making a completion request
+    let mut stream = model
+        .complete(&messages, None, &settings, CancellationToken::new())
+        .await;
+    while let Some(result) = stream.next().await {
+        if let Ok(Completion::Response(_)) = result {
+            break;
+        }
+    }
+
+    // Get metrics
+    let metrics = model.metrics();
+
+    println!(
+        "Model metrics: {:?}",
+        serde_json::to_string_pretty(&metrics).unwrap()
+    );
+
+    // Verify system info is populated
+    assert!(metrics.cpu_threads.is_some(), "cpu_threads should be set");
+    assert!(metrics.gpu_devices.is_some(), "gpu_devices should be set");
+
+    // Verify computed parameters are populated
+    assert!(metrics.n_ctx.is_some(), "n_ctx should be set");
+    assert!(metrics.n_batch.is_some(), "n_batch should be set");
+    assert!(metrics.n_ubatch.is_some(), "n_ubatch should be set");
+    assert!(metrics.n_gpu_layers.is_some(), "n_gpu_layers should be set");
+    assert!(metrics.n_threads.is_some(), "n_threads should be set");
+    assert!(
+        metrics.flash_attention.is_some(),
+        "flash_attention should be set"
+    );
+
+    // Verify model info from GGUF metadata is populated
+    assert!(
+        metrics.model_params_billions.is_some(),
+        "model_params_billions should be set"
+    );
+    assert!(metrics.model_layers.is_some(), "model_layers should be set");
+    assert!(metrics.quantization.is_some(), "quantization should be set");
+    assert!(
+        metrics.model_n_ctx_train.is_some(),
+        "model_n_ctx_train should be set"
+    );
+
+    // Verify values are reasonable
+    let n_ctx = metrics.n_ctx.unwrap();
+    assert!(n_ctx >= 512, "n_ctx should be at least 512");
+
+    let n_threads = metrics.n_threads.unwrap();
+    assert!(n_threads >= 1, "n_threads should be at least 1");
+
+    let model_params = metrics.model_params_billions.unwrap();
+    assert!(
+        model_params > 0.0,
+        "model_params_billions should be positive"
+    );
+
+    println!("All model params verified:");
+    println!("  - cpu_threads: {:?}", metrics.cpu_threads);
+    println!("  - n_ctx: {:?}", metrics.n_ctx);
+    println!("  - n_batch: {:?}", metrics.n_batch);
+    println!("  - n_gpu_layers: {:?}", metrics.n_gpu_layers);
+    println!("  - model_params_billions: {:.2}", model_params);
+    println!("  - quantization: {:?}", metrics.quantization);
+}
+
+#[tokio::test]
+async fn test_oom_recovery_with_trim() {
+    // Skip on CI
+    if std::env::var("CI").is_ok() {
+        eprintln!("Skipping test_oom_recovery_with_trim on CI");
+        return;
+    }
+
+    init_tracing();
+
+    // Create a dedicated model with small context for OOM testing
+    let model = get_shared_oom_model().await.unwrap();
+
+    // Add many messages to fill context - use repetitive text to quickly fill
+    // Use smaller repeated text to fit within 512 context without exceeding
+    let long_text = "Hello, how are you? Please respond with a detailed explanation. ".repeat(3);
+
+    // Create prompt that fits within context (under 512 tokens)
+    let prompt = long_text;
+
+    let mut settings = HashMap::new();
+    settings.insert("max_tokens".to_string(), "10".to_string());
+
+    let messages = vec![ChatMessage {
+        sender: SenderType::User,
+        text: prompt,
+        ..Default::default()
+    }];
+
+    let mut stream = model
+        .complete(&messages, None, &settings, CancellationToken::new())
+        .await;
+
+    let mut received_response = false;
+    let mut finished = false;
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(Completion::Response(resp)) => {
+                received_response = true;
+                println!(
+                    "Response: text_len={}, finish_reason={:?}",
+                    resp.text.len(),
+                    resp.finish_reason
+                );
+                if resp.finish_reason.is_some() {
+                    finished = true;
+                }
+            }
+            Ok(Completion::Metrics(m)) => {
+                println!(
+                    "Metrics: prompt_tokens={}, completion_tokens={}",
+                    m.prompt_tokens, m.completion_tokens
+                );
+            }
+            Err(e) => {
+                println!("Error: {}", e);
+            }
+        }
+    }
+
+    println!(
+        "Test result: received_response={}, finished={}",
+        received_response, finished
+    );
+
+    assert!(received_response, "Should receive response");
 }

--- a/crates/tools-search/src/lib.rs
+++ b/crates/tools-search/src/lib.rs
@@ -79,33 +79,10 @@ impl Tool for SearchTool {
                     "default": "markdown",
                     "description": "Output format. Use 'markdown' for human-readable results, 'json' for structured data."
                 },
-                "language": {
-                    "type": "string",
-                    "description": "Language code (e.g., en, de, fr). Uses instance default if not specified."
-                },
-                "time_range": {
-                    "type": "string",
-                    "enum": ["day", "month", "year"],
-                    "description": "Limit results to recency. Only works with engines that support it."
-                },
                 "categories": {
                     "type": "string",
                     "description": "Comma-separated categories: general, images, videos, news, map, music, it, science, files, social_media"
                 },
-                "safesearch": {
-                    "type": "integer",
-                    "enum": [0, 1, 2],
-                    "description": "SafeSearch level: 0=none, 1=moderate, 2=strict"
-                },
-                "engines": {
-                    "type": "string",
-                    "description": "Comma-separated engine names (e.g., google, bing, duckduckgo)"
-                },
-                "pageno": {
-                    "type": "integer",
-                    "default": 1,
-                    "description": "Page number for pagination"
-                }
             },
             "required": ["query"]
         })
@@ -135,13 +112,13 @@ impl Tool for SearchTool {
             .with_context(|| format!("Search failed for query: {query}"))
             .map_err(|e| ToolError::ExecutionError(e.to_string()))?;
 
-        debug!(?results, "Search results received");
-
         let output = if format == "markdown" {
             Value::String(format_results_markdown(query, &results))
         } else {
             serde_json::to_value(results).map_err(|e| ToolError::ExecutionError(e.to_string()))?
         };
+
+        debug!(?output, "Search results output");
 
         Ok(output)
     }


### PR DESCRIPTION
- Rename thinking to reasoning (enable_reasoning, set_enable_reasoning)
- Refactor Session API with SessionConfig for tools, system_prompt
- Add context module for message trimming and compaction
- Add registry module for model/provider registry
- Add GGUF system prompt support
- Stream SessionEvent instead of Completion directly
- Bump llama-cpp-2 to 0.1.143